### PR TITLE
feat: 알림 페이지 WebSocket 구독 및 로컬 알림 저장 구현

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -8,6 +8,24 @@ declare module '*.css' {
   export default classes
 }
 
+declare module 'sockjs-client' {
+  class SockJS {
+    constructor(url: string, protocols?: string | string[], options?: any)
+    send(data: string): void
+    close(): void
+    onopen: ((event: any) => void) | null
+    onmessage: ((event: any) => void) | null
+    onclose: ((event: any) => void) | null
+    onerror: ((event: any) => void) | null
+    readyState: number
+    url: string
+    protocol: string
+    extensions: string
+    bufferedAmount: number
+  }
+  export = SockJS
+}
+
 // If your project uses imported images or SVGs in TSX, consider adding:
 // declare module '*.svg'
 // declare module '*.png'

--- a/src/pages/NotificationPage/NotificationPage.tsx
+++ b/src/pages/NotificationPage/NotificationPage.tsx
@@ -1,5 +1,10 @@
-import { useMemo, useState, useEffect } from 'react'
+import { useMemo, useState, useEffect, useRef } from 'react'
 import { Folder } from 'lucide-react'
+import { Client } from '@stomp/stompjs'
+// @ts-ignore - sockjs-client 타입 정의 없음
+import SockJS from 'sockjs-client'
+import axios from 'axios'
+import { SOCKET_SERVER_URL, API_BASE_URL } from '../../config/api'
 import Sidebar from '../MainPage/components/Sidebar/Sidebar'
 import styles from './NotificationPage.module.css'
 
@@ -13,66 +18,6 @@ interface Notification {
   isRead: boolean
   userImage?: string
 }
-
-// 더미 데이터
-const DUMMY_NOTIFICATIONS: Notification[] = [
-  {
-    id: '1',
-    projectName: '2024 마케팅 기획',
-    userName: '김철수',
-    timestamp: new Date(Date.now() - 5 * 60000),
-    type: 'enter',
-    isRead: false
-  },
-  {
-    id: '2',
-    projectName: '제품 기획안',
-    userName: '이영희',
-    timestamp: new Date(Date.now() - 12 * 60000),
-    type: 'leave',
-    isRead: false
-  },
-  {
-    id: '3',
-    projectName: '디자인 시스템',
-    userName: '박민준',
-    timestamp: new Date(Date.now() - 25 * 60000),
-    type: 'enter',
-    isRead: true
-  },
-  {
-    id: '4',
-    projectName: '2024 마케팅 기획',
-    userName: '정수진',
-    timestamp: new Date(Date.now() - 45 * 60000),
-    type: 'leave',
-    isRead: true
-  },
-  {
-    id: '5',
-    projectName: '모바일 앱 개발',
-    userName: '이준호',
-    timestamp: new Date(Date.now() - 1.5 * 60 * 60000),
-    type: 'enter',
-    isRead: false
-  },
-  {
-    id: '6',
-    projectName: '제품 기획안',
-    userName: '강예은',
-    timestamp: new Date(Date.now() - 2.5 * 60 * 60000),
-    type: 'enter',
-    isRead: true
-  },
-  {
-    id: '7',
-    projectName: '디자인 시스템',
-    userName: '조대운',
-    timestamp: new Date(Date.now() - 3 * 60 * 60000),
-    type: 'leave',
-    isRead: true
-  }
-]
 
 // 시간 포맷팅 함수
 function formatTime(date: Date): string {
@@ -105,9 +50,40 @@ function getUserInitials(name: string): string {
   return 'U'
 }
 
+// localStorage에서 알림 불러오기
+const loadNotificationsFromStorage = (): Notification[] => {
+  try {
+    const stored = localStorage.getItem('notifications')
+    if (stored) {
+      const parsed = JSON.parse(stored)
+      // Date 객체 복원
+      return parsed.map((n: any) => ({
+        ...n,
+        timestamp: new Date(n.timestamp)
+      }))
+    }
+  } catch (e) {
+    console.error('[알림] localStorage에서 알림 불러오기 실패:', e)
+  }
+  return []
+}
+
+// localStorage에 알림 저장
+const saveNotificationsToStorage = (notifications: Notification[]) => {
+  try {
+    localStorage.setItem('notifications', JSON.stringify(notifications))
+  } catch (e) {
+    console.error('[알림] localStorage에 알림 저장 실패:', e)
+  }
+}
+
 export default function NotificationPage(): JSX.Element {
   const [currentUserImage, setCurrentUserImage] = useState<string>('')
-  const [notifications, setNotifications] = useState<Notification[]>(DUMMY_NOTIFICATIONS)
+  const [notifications, setNotifications] = useState<Notification[]>(loadNotificationsFromStorage)
+  const [workspaces, setWorkspaces] = useState<Array<{ workspaceId: number; name: string }>>([])
+  const clientRef = useRef<Client | null>(null)
+  const subscriptionsRef = useRef<Array<{ path: string; subscription: any }>>([])
+  const workspaceMapRef = useRef<Map<number, string>>(new Map())
 
   // 사용자 프로필 이미지 로드
   useEffect(() => {
@@ -117,13 +93,304 @@ export default function NotificationPage(): JSX.Element {
     }
   }, [])
 
+  // 워크스페이스 목록 불러오기
+  useEffect(() => {
+    const fetchWorkspaces = async () => {
+      try {
+        const accessToken = localStorage.getItem('accessToken')
+        if (!accessToken) {
+          console.warn('[알림] 로그인이 필요합니다.')
+          return
+        }
+
+        console.log('[알림] 워크스페이스 목록 불러오기 시작')
+        const res = await axios.get<Array<{ workspaceId: number; name: string }>>(
+          `${API_BASE_URL}/v1/workspaces`,
+          {
+            headers: {
+              'Authorization': `Bearer ${accessToken}`
+            }
+          }
+        )
+
+        console.log('[알림] 워크스페이스 목록 불러오기 완료:', res.data.length, '개')
+        setWorkspaces(res.data)
+        // 워크스페이스 ID -> 이름 매핑 저장
+        const map = new Map<number, string>()
+        res.data.forEach(ws => {
+          map.set(ws.workspaceId, ws.name)
+          console.log('[알림] 워크스페이스 매핑:', ws.workspaceId, '->', ws.name)
+        })
+        workspaceMapRef.current = map
+      } catch (err) {
+        console.error('[알림] 워크스페이스 목록 불러오기 실패:', err)
+      }
+    }
+
+    fetchWorkspaces()
+    
+    // 주기적으로 워크스페이스 목록 갱신 (30초마다)
+    const interval = setInterval(() => {
+      fetchWorkspaces()
+    }, 30000)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [])
+
+  // WebSocket 구독 설정
+  useEffect(() => {
+    if (workspaces.length === 0) {
+      console.log('[알림 웹소켓] 워크스페이스 목록이 비어있어 구독을 건너뜁니다.')
+      return
+    }
+
+    const accessToken = localStorage.getItem('accessToken')
+    if (!accessToken) {
+      console.log('[알림 웹소켓] 액세스 토큰이 없어 구독을 건너뜁니다.')
+      return
+    }
+
+    console.log('[알림 웹소켓] 구독 설정 시작 - 워크스페이스 개수:', workspaces.length)
+    workspaces.forEach(ws => {
+      console.log('[알림 웹소켓] 워크스페이스:', ws.workspaceId, ws.name)
+    })
+
+    // 기존 연결이 있으면 정리
+    if (clientRef.current) {
+      console.log('[알림 웹소켓] 기존 연결 정리 시작')
+      if (clientRef.current.connected) {
+        subscriptionsRef.current.forEach(sub => {
+          try {
+            sub.subscription.unsubscribe()
+            console.log('[알림 웹소켓] 구독 해제:', sub.path)
+          } catch (e) {
+            console.error('[알림 웹소켓] 구독 해제 오류:', e)
+          }
+        })
+        subscriptionsRef.current = []
+      }
+      try {
+        clientRef.current.deactivate()
+        console.log('[알림 웹소켓] 기존 연결 비활성화 완료')
+      } catch (e) {
+        console.error('[알림 웹소켓] 연결 해제 오류:', e)
+      }
+    }
+
+    // STOMP 클라이언트 생성
+    const socketUrl = `${SOCKET_SERVER_URL}/ws`
+    console.log('[알림 웹소켓] 소켓 URL:', socketUrl)
+    const socket = new SockJS(socketUrl)
+    const stompClient = new Client({
+      webSocketFactory: () => socket,
+      connectHeaders: {
+        Authorization: `Bearer ${accessToken}`
+      },
+      reconnectDelay: 5000,
+      heartbeatIncoming: 4000,
+      heartbeatOutgoing: 4000,
+      debug: (str) => {
+        console.log('[알림 웹소켓] STOMP 디버그:', str)
+      },
+      onConnect: (frame) => {
+        console.log('[알림 웹소켓] 연결 성공:', frame)
+        console.log('[알림 웹소켓] 연결된 워크스페이스 개수:', workspaces.length)
+
+        // 각 워크스페이스에 대해 알림 구독
+        workspaces.forEach(workspace => {
+          const subscriptionPath = `/topic/workspace/${workspace.workspaceId}/users`
+          console.log('[알림 웹소켓] 구독 시작:', subscriptionPath)
+
+          try {
+            const subscription = stompClient.subscribe(subscriptionPath, (message) => {
+              console.log('[알림 웹소켓] 알림 수신:', message.body)
+              
+              try {
+                let data: any
+                let messageText: string = ''
+                
+                // 메시지가 JSON 형식인지 확인
+                try {
+                  data = JSON.parse(message.body)
+                  messageText = data.message || message.body
+                } catch {
+                  // JSON이 아니면 문자열로 처리
+                  messageText = message.body
+                  data = { message: messageText }
+                }
+                
+                console.log('[알림 웹소켓] 파싱된 데이터:', data)
+                console.log('[알림 웹소켓] 메시지 텍스트:', messageText)
+
+                // 현재 사용자 ID 추출
+                let currentUserId: string | null = null
+                try {
+                  const tokenPayload = JSON.parse(atob(accessToken.split('.')[1]))
+                  currentUserId = String(tokenPayload.user_id || tokenPayload.sub)
+                } catch (e) {
+                  console.warn('JWT 토큰 파싱 실패:', e)
+                }
+
+                // 자신이 발생시킨 이벤트는 무시
+                if (data.userId && String(data.userId) === currentUserId) {
+                  console.log('[알림 웹소켓] 자신의 이벤트 무시')
+                  return
+                }
+
+                // 알림 타입 확인
+                let notificationType = data.type
+                if (!notificationType) {
+                  // 메시지 내용으로 타입 추론
+                  if (messageText.includes('참여') || messageText.includes('입장')) {
+                    notificationType = 'user_joined'
+                  } else if (messageText.includes('떠났') || messageText.includes('나갔') || messageText.includes('퇴장') || messageText.includes('제거')) {
+                    notificationType = 'user_left'
+                  } else {
+                    // 기본값: 메시지가 있으면 참여로 간주
+                    notificationType = 'user_joined'
+                  }
+                }
+                const isEnter = notificationType === 'user_joined' || notificationType === 'enter'
+
+                // 워크스페이스 이름 가져오기
+                const workspaceName = workspaceMapRef.current.get(workspace.workspaceId) || workspace.name || '알 수 없는 프로젝트'
+                
+                // 사용자 이름 추출 (백엔드에서 JSON으로 보내면 우선 사용)
+                let userName = data.userName || data.name
+                if (!userName || userName === '알 수 없는 사용자') {
+                  // 메시지에서 사용자 이름 추출 시도
+                  // "사용자 {name}가 워크스페이스에 참여했습니다." 형식
+                  // "사용자 {name}가 워크스페이스를 떠났습니다." 형식
+                  // "사용자 {name}가 워크스페이스에서 제거되었습니다." 형식
+                  const match = messageText.match(/사용자\s+([^가님이]+?)(?:가|님이)/)
+                  if (match) {
+                    userName = match[1].trim()
+                  } else {
+                    // "사용자 {name}가" 형식 (더 넓은 범위)
+                    const match2 = messageText.match(/사용자\s+([^가]+)가/)
+                    if (match2) {
+                      userName = match2[1].trim()
+                    } else {
+                      // "{name}님이" 형식
+                      const match3 = messageText.match(/([^님이]+)님이/)
+                      if (match3) {
+                        userName = match3[1].trim()
+                      } else {
+                        console.warn('[알림 웹소켓] 사용자 이름 추출 실패, 메시지:', messageText)
+                        userName = '알 수 없는 사용자'
+                      }
+                    }
+                  }
+                }
+                
+                console.log('[알림 웹소켓] 추출된 사용자 이름:', userName, '원본 메시지:', messageText)
+
+                // 새 알림 생성
+                const newNotification: Notification = {
+                  id: `${workspace.workspaceId}-${Date.now()}-${Math.random()}`,
+                  projectName: workspaceName,
+                  userName: userName,
+                  timestamp: new Date(),
+                  type: isEnter ? 'enter' : 'leave',
+                  isRead: false
+                }
+
+                // 알림 목록에 추가 (항상 추가, 중복 방지는 타임스탬프 기반으로만)
+                setNotifications(prev => {
+                  // 같은 워크스페이스, 같은 사용자, 같은 타입의 매우 최근 알림(1초 이내)만 무시
+                  const veryRecent = prev.find(n => 
+                    n.projectName === newNotification.projectName &&
+                    n.userName === newNotification.userName &&
+                    n.type === newNotification.type &&
+                    Math.abs(newNotification.timestamp.getTime() - n.timestamp.getTime()) < 1000 // 1초 이내
+                  )
+                  if (veryRecent) {
+                    console.log('[알림 웹소켓] 매우 최근 중복 알림 무시 (1초 이내)')
+                    return prev
+                  }
+                  console.log('[알림 웹소켓] 새 알림 추가:', newNotification)
+                  const updated = [newNotification, ...prev]
+                  // localStorage에 저장
+                  saveNotificationsToStorage(updated)
+                  return updated
+                })
+              } catch (e) {
+                console.error('[알림 웹소켓] 메시지 파싱 오류:', e)
+                console.error('[알림 웹소켓] 원본 body:', message.body)
+              }
+            })
+
+            subscriptionsRef.current.push({ path: subscriptionPath, subscription })
+            console.log('[알림 웹소켓] 구독 완료:', subscriptionPath, '구독 ID:', subscription.id)
+          } catch (subscribeError) {
+            console.error('[알림 웹소켓] 구독 오류:', subscriptionPath, subscribeError)
+          }
+        })
+        
+        console.log('[알림 웹소켓] 총 구독 개수:', subscriptionsRef.current.length)
+        subscriptionsRef.current.forEach(sub => {
+          console.log('[알림 웹소켓] 활성 구독:', sub.path)
+        })
+      },
+      onStompError: (frame) => {
+        console.error('[알림 웹소켓] STOMP 오류:', frame)
+        console.error('[알림 웹소켓] STOMP 오류 상세:', {
+          command: frame.command,
+          headers: frame.headers,
+          body: frame.body
+        })
+      },
+      onWebSocketClose: (event) => {
+        console.log('[알림 웹소켓] WebSocket 연결 해제:', event)
+        console.log('[알림 웹소켓] 종료 코드:', event.code, '이유:', event.reason)
+      },
+      onDisconnect: () => {
+        console.log('[알림 웹소켓] STOMP 연결 끊김')
+      },
+      onWebSocketError: (event) => {
+        console.error('[알림 웹소켓] WebSocket 오류:', event)
+      }
+    })
+
+    clientRef.current = stompClient
+    console.log('[알림 웹소켓] STOMP 클라이언트 활성화 시작')
+    stompClient.activate()
+
+    // 정리 함수
+    return () => {
+      console.log('[알림 웹소켓] 정리 시작')
+      subscriptionsRef.current.forEach(sub => {
+        try {
+          sub.subscription.unsubscribe()
+        } catch (e) {
+          console.error('구독 해제 오류:', e)
+        }
+      })
+      subscriptionsRef.current = []
+      
+      if (clientRef.current) {
+        try {
+          clientRef.current.deactivate()
+        } catch (e) {
+          console.error('WebSocket 연결 해제 오류:', e)
+        }
+        clientRef.current = null
+      }
+    }
+  }, [workspaces])
+
   // 알림 클릭 시 읽음 처리
   const handleNotificationClick = (id: string) => {
-    setNotifications(prev =>
-      prev.map(notif =>
+    setNotifications(prev => {
+      const updated = prev.map(notif =>
         notif.id === id ? { ...notif, isRead: true } : notif
       )
-    )
+      // localStorage에 저장
+      saveNotificationsToStorage(updated)
+      return updated
+    })
   }
 
   // 최신순으로 정렬된 알림


### PR DESCRIPTION
   ### 변경사항

   알림 페이지에서 워크스페이스 참가/퇴장 알림을 WebSocket으로 구독하고, 알림을 localStorage에 저장해 새로고침 후에도 유지되도록 개선했습니다.

   **프론트엔드 변경사항:**

   1. **NotificationPage 알림 구독 추가**
      - `/v1/workspaces` API로 사용자가 속한 워크스페이스 목록을 불러온 뒤, 각 워크스페이스에 대해 `/topic/workspace/{workspaceId}/users` 토픽을 STOMP WebSocket으로 구독합니다.
      - 백엔드에서 보내는 JSON 형식 알림(`type`, `userId`, `userName`, `message`)과 문자열 형식 모두 처리하도록 파싱 로직을 구현했습니다.
      - 자기 자신이 발생시킨 이벤트(`data.userId === currentUserId`)는 무시하여 중복 UI 업데이트를 방지합니다.

   2. **알림 데이터 구조 및 파싱 로직 개선**
      - 알림 타입을 `type` 필드와 메시지 내용(참여/입장/떠났/나갔/퇴장/제거)에 따라 `enter`/`leave`로 매핑합니다.
      - 사용자 이름은 우선 `data.userName`을 사용하고, 없을 경우 `"사용자 {name}가 ..."` / `"{name}님이 ..."` 패턴을 정규식으로 파싱해 최대한 실제 이름을 표시합니다.
      - 워크스페이스 이름은 `/v1/workspaces` 응답을 기반으로 `workspaceId → name` 매핑을 만들어 사용합니다.

   3. **알림 영구 저장 (localStorage)**
      - `loadNotificationsFromStorage` / `saveNotificationsToStorage` 유틸 함수를 추가하여 알림 배열을 `localStorage.notifications`에 JSON으로 저장/복원합니다.
      - `timestamp` 필드는 복원 시 `Date` 객체로 되살려 시간 표시(`방금 전`, `n분 전` 등)에 사용합니다.
      - 새 알림 추가 및 읽음 처리(카드 클릭 시 `isRead: true`) 시마다 localStorage를 함께 업데이트합니다.
      - 동일 워크스페이스/사용자/타입에 대해 1초 이내에 반복되는 알림만 중복으로 간주해 무시하고, 그 외 알림은 모두 남겨 사용자가 히스토리를 확인할 수 있도록 합니다.

   4. **타입 정의 보완**
      - `src/custom.d.ts`에 `declare module 'sockjs-client'` 선언을 추가해 `sockjs-client` 타입 오류를 제거하고, TS 컴파일이 깨지지 않도록 했습니다.

   ### 테스트

   - [ ] 테스트 코드
   - [x] 수동 UI 테스트

   **수동 테스트 시나리오:**

   1. 브라우저 A/B 두 개를 열고 동일 계정으로 로그인 후, 같은 워크스페이스에 접속합니다.
   2. 브라우저 B에서 초대 수락 또는 워크스페이스 입장/퇴장/제거를 수행합니다.
   3. 브라우저 A의 `/notifications` 페이지에서:
      - 새로운 알림 카드가 실시간으로 추가되는지 확인합니다.
      - 사용자 이름과 워크스페이스 이름이 올바르게 표시되는지 확인합니다.
      - 알림 카드를 클릭하면 읽음 처리(`isRead`)가 되고, 스타일이 변경되는지 확인합니다.
   4. 페이지를 새로고침한 후에도 기존 알림들이 그대로 유지되는지(localStorage 복원) 확인합니다.