### PR TITLE
Feat/notification page websocket subscription

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -8,6 +8,24 @@ declare module '*.css' {
   export default classes
 }
 
+declare module 'sockjs-client' {
+  class SockJS {
+    constructor(url: string, protocols?: string | string[], options?: any)
+    send(data: string): void
+    close(): void
+    onopen: ((event: any) => void) | null
+    onmessage: ((event: any) => void) | null
+    onclose: ((event: any) => void) | null
+    onerror: ((event: any) => void) | null
+    readyState: number
+    url: string
+    protocol: string
+    extensions: string
+    bufferedAmount: number
+  }
+  export = SockJS
+}
+
 // If your project uses imported images or SVGs in TSX, consider adding:
 // declare module '*.svg'
 // declare module '*.png'

--- a/src/pages/MainPage/components/Sidebar/Sidebar.tsx
+++ b/src/pages/MainPage/components/Sidebar/Sidebar.tsx
@@ -1,27 +1,118 @@
+import { useState, useEffect } from 'react'
+
 import styles from './Sidebar.module.css'
+
 import {
   LayoutDashboard,
   Bell,
   Star,
+  Trash2,
   Settings,
-  LogOut,
-  Trash2
+  LogOut
 } from 'lucide-react'
 import { useNavigate, Link } from 'react-router-dom'
+import axios from 'axios'
+import { API_BASE_URL } from '../../../../config/api'
 
 interface SidebarProps {
   activeMenu?: string
   unreadNotifications?: boolean
 }
 
-export default function Sidebar({ activeMenu = 'home', unreadNotifications = false }: SidebarProps) {
-  // TODO: 사용자 정보 fetch 및 프로필 구현은 기존과 동일하게 유지 (생략)
-  // 임시 프로필
-  const userName = '사용자'
-  const userInitials = 'U'
-  const profileImage = null
+interface UserInfo {
+  id: number
+  email: string
+  name: string
+  profileImage: string | null
+}
 
-  // 메뉴 정의 (상단 통합)
+// 사용자 이름에서 이니셜 추출 함수
+function getInitials(name: string): string {
+  if (!name) return 'U'
+  const parts = name.trim().split(/\s+/)
+  if (parts.length >= 2) {
+    // 이름과 성이 모두 있으면 각각의 첫 글자
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+  } else if (parts.length === 1) {
+    // 한 단어면 첫 두 글자
+    return parts[0].substring(0, 2).toUpperCase()
+  }
+  return 'U'
+}
+
+export default function Sidebar({ activeMenu = 'home', unreadNotifications = false }: SidebarProps) {
+  const [userName, setUserName] = useState<string>('사용자')
+  const [userInitials, setUserInitials] = useState<string>('U')
+  const [profileImage, setProfileImage] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const accessToken = localStorage.getItem('accessToken')
+        if (!accessToken) {
+          // 토큰이 없으면 localStorage에서 기본 정보 사용
+          const storedName = localStorage.getItem('userName')
+          if (storedName) {
+            setUserName(storedName)
+            setUserInitials(getInitials(storedName))
+          }
+          return
+        }
+
+        const res = await axios.get<UserInfo>(
+          `${API_BASE_URL}/v1/users/me`,
+          {
+            headers: {
+              'Authorization': `Bearer ${accessToken}`
+            }
+          }
+        )
+
+        // 사용자 정보 설정
+        if (res.data.name) {
+          setUserName(res.data.name)
+          setUserInitials(getInitials(res.data.name))
+        }
+        if (res.data.profileImage) {
+          setProfileImage(res.data.profileImage)
+        }
+
+        // localStorage에도 저장 (다른 곳에서 사용할 수 있도록)
+        if (res.data.name) {
+          localStorage.setItem('userName', res.data.name)
+        }
+        if (res.data.email) {
+          localStorage.setItem('userEmail', res.data.email)
+        }
+      } catch (err: any) {
+        console.error('사용자 정보 불러오기 실패', err)
+        // axios 오류인지 확인
+        const isAxiosError = err?.isAxiosError || err?.response !== undefined || err?.request !== undefined
+        const status = err?.response?.status
+
+        // 401 또는 403 오류인 경우 토큰 제거
+        if (isAxiosError && (status === 401 || status === 403)) {
+          localStorage.removeItem('accessToken')
+          localStorage.removeItem('refreshToken')
+          localStorage.removeItem('userName')
+          localStorage.removeItem('userEmail')
+          // 페이지 새로고침하여 MainPage의 모달이 표시되도록 함
+          window.location.reload()
+        } else {
+          // 실패 시 localStorage에서 기본 정보 사용
+          const storedName = localStorage.getItem('userName')
+          if (storedName) {
+            setUserName(storedName)
+            setUserInitials(getInitials(storedName))
+          }
+        }
+      }
+    }
+
+    fetchUserInfo()
+  }, [])
+
+  // 메뉴 정의 (상단)
   const topMenus = [
     { key: 'home', label: '홈', icon: LayoutDashboard, href: '/' },
     { key: 'notifications', label: '알림', icon: Bell, href: '/notifications', badge: unreadNotifications },
@@ -32,15 +123,16 @@ export default function Sidebar({ activeMenu = 'home', unreadNotifications = fal
 
   // 실제 로그아웃 처리 함수
   function handleLogout() {
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
-    localStorage.removeItem('userName');
-    localStorage.removeItem('userEmail');
-    navigate('/auth', { replace: true });
+    localStorage.removeItem('accessToken')
+    localStorage.removeItem('refreshToken')
+    localStorage.removeItem('userName')
+    localStorage.removeItem('userEmail')
+    navigate('/auth', { replace: true })
   }
 
   return (
     <aside className={styles.sidebar} aria-label="사이드바">
+      {/* 프로필 영역 */}
       <div className={styles.profile}>
         <div className={styles.avatar}>
           {profileImage ? (
@@ -54,64 +146,60 @@ export default function Sidebar({ activeMenu = 'home', unreadNotifications = fal
           <div className={styles.meta}>프로필</div>
         </div>
       </div>
-      <nav className={styles.nav} aria-label="사이드바 메뉴">
+
+      <nav className="flex flex-col flex-1" aria-label="사이드바 메뉴">
         <ul className="flex flex-col gap-1">
           {topMenus.map(item => {
             const active = activeMenu === item.key
-            const Icon = item.icon
-            if (!Icon) return null
+            const Icon = item.icon as (typeof LayoutDashboard) | undefined
+
             return (
               <li key={item.key}>
-                <a
-                  href={item.href}
+                <Link
+                  to={item.href || '#'}
                   className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm font-medium ${active ? 'bg-green-50 text-green-600' : 'text-gray-700 hover:bg-gray-50 hover:text-green-600'}`}
                   aria-current={active ? 'page' : undefined}
                 >
-                  <span className="w-6 h-6 flex items-center justify-center relative">
-                    <Icon className={active ? 'text-green-600' : 'text-gray-400 group-hover:text-green-600'} size={20} />
-                    {item.key === 'notifications' && item.badge ? (
-                      <span className="absolute top-0 right-0 block w-2 h-2 bg-red-500 rounded-full ring-2 ring-white" style={{ marginLeft: 14, marginTop: -2 }} />
-                    ) : null}
-                  </span>
+                  {Icon && <Icon size={20} className={active ? 'text-green-600' : 'text-gray-400'} />}
                   <span>{item.label}</span>
-                </a>
+                  {item.key === 'notifications' && (item as any).badge ? (
+                    <span className="ml-auto block w-2 h-2 bg-red-500 rounded-full" />
+                  ) : null}
+                </Link>
               </li>
             )
           })}
         </ul>
-        {/* 하단 Footer Section */}
-        <div className="mt-auto border-t pt-2 pb-4 px-2 flex flex-col gap-1">
+
+        {/* 하단 섹션: 휴지통, 설정, 로그아웃 */}
+        <div className="mt-auto border-t border-gray-200 pt-4 pb-2 flex flex-col gap-1">
           {/* 휴지통 메뉴 */}
           <Link
             to="/trash"
             className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm font-medium ${activeMenu === 'trash' ? 'bg-red-50 text-red-600' : 'text-gray-700 hover:bg-gray-50 hover:text-red-600'}`}
             aria-current={activeMenu === 'trash' ? 'page' : undefined}
           >
-            <span className="w-6 h-6 flex items-center justify-center">
-              <Trash2 className={activeMenu === 'trash' ? 'text-red-600' : 'text-gray-400 group-hover:text-red-600'} size={20} />
-            </span>
+            <Trash2 size={20} className={activeMenu === 'trash' ? 'text-red-600' : 'text-gray-400'} />
             <span>휴지통</span>
           </Link>
+
           {/* 설정 메뉴 */}
           <Link
             to="/settings"
             className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm font-medium ${activeMenu === 'settings' ? 'bg-green-50 text-green-600' : 'text-gray-700 hover:bg-gray-50 hover:text-green-600'}`}
             aria-current={activeMenu === 'settings' ? 'page' : undefined}
           >
-            <span className="w-6 h-6 flex items-center justify-center">
-              <Settings className={activeMenu === 'settings' ? 'text-green-600' : 'text-gray-400 group-hover:text-green-600'} size={20} />
-            </span>
+            <Settings size={20} className={activeMenu === 'settings' ? 'text-green-600' : 'text-gray-400'} />
             <span>설정</span>
           </Link>
+
           {/* 로그아웃 버튼 */}
           <button
             type="button"
-            className="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm font-medium text-gray-700 mt-1 hover:bg-red-50 hover:text-red-600"
+            className="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors text-sm font-medium text-gray-700 w-full hover:bg-red-50 hover:text-red-600"
             onClick={handleLogout}
           >
-            <span className="w-6 h-6 flex items-center justify-center">
-              <LogOut className="text-gray-400 group-hover:text-red-600" size={20} />
-            </span>
+            <LogOut size={20} className="text-gray-400" />
             <span>로그아웃</span>
           </button>
         </div>

--- a/src/pages/NotificationPage/NotificationPage.tsx
+++ b/src/pages/NotificationPage/NotificationPage.tsx
@@ -1,5 +1,10 @@
-import { useMemo, useState, useEffect } from 'react'
+import { useMemo, useState, useEffect, useRef } from 'react'
 import { Folder } from 'lucide-react'
+import { Client } from '@stomp/stompjs'
+// @ts-ignore - sockjs-client 타입 정의 없음
+import SockJS from 'sockjs-client'
+import axios from 'axios'
+import { SOCKET_SERVER_URL, API_BASE_URL } from '../../config/api'
 import Sidebar from '../MainPage/components/Sidebar/Sidebar'
 import styles from './NotificationPage.module.css'
 
@@ -13,66 +18,6 @@ interface Notification {
   isRead: boolean
   userImage?: string
 }
-
-// 더미 데이터
-const DUMMY_NOTIFICATIONS: Notification[] = [
-  {
-    id: '1',
-    projectName: '2024 마케팅 기획',
-    userName: '김철수',
-    timestamp: new Date(Date.now() - 5 * 60000),
-    type: 'enter',
-    isRead: false
-  },
-  {
-    id: '2',
-    projectName: '제품 기획안',
-    userName: '이영희',
-    timestamp: new Date(Date.now() - 12 * 60000),
-    type: 'leave',
-    isRead: false
-  },
-  {
-    id: '3',
-    projectName: '디자인 시스템',
-    userName: '박민준',
-    timestamp: new Date(Date.now() - 25 * 60000),
-    type: 'enter',
-    isRead: true
-  },
-  {
-    id: '4',
-    projectName: '2024 마케팅 기획',
-    userName: '정수진',
-    timestamp: new Date(Date.now() - 45 * 60000),
-    type: 'leave',
-    isRead: true
-  },
-  {
-    id: '5',
-    projectName: '모바일 앱 개발',
-    userName: '이준호',
-    timestamp: new Date(Date.now() - 1.5 * 60 * 60000),
-    type: 'enter',
-    isRead: false
-  },
-  {
-    id: '6',
-    projectName: '제품 기획안',
-    userName: '강예은',
-    timestamp: new Date(Date.now() - 2.5 * 60 * 60000),
-    type: 'enter',
-    isRead: true
-  },
-  {
-    id: '7',
-    projectName: '디자인 시스템',
-    userName: '조대운',
-    timestamp: new Date(Date.now() - 3 * 60 * 60000),
-    type: 'leave',
-    isRead: true
-  }
-]
 
 // 시간 포맷팅 함수
 function formatTime(date: Date): string {
@@ -105,9 +50,40 @@ function getUserInitials(name: string): string {
   return 'U'
 }
 
+// localStorage에서 알림 불러오기
+const loadNotificationsFromStorage = (): Notification[] => {
+  try {
+    const stored = localStorage.getItem('notifications')
+    if (stored) {
+      const parsed = JSON.parse(stored)
+      // Date 객체 복원
+      return parsed.map((n: any) => ({
+        ...n,
+        timestamp: new Date(n.timestamp)
+      }))
+    }
+  } catch (e) {
+    console.error('[알림] localStorage에서 알림 불러오기 실패:', e)
+  }
+  return []
+}
+
+// localStorage에 알림 저장
+const saveNotificationsToStorage = (notifications: Notification[]) => {
+  try {
+    localStorage.setItem('notifications', JSON.stringify(notifications))
+  } catch (e) {
+    console.error('[알림] localStorage에 알림 저장 실패:', e)
+  }
+}
+
 export default function NotificationPage(): JSX.Element {
   const [currentUserImage, setCurrentUserImage] = useState<string>('')
-  const [notifications, setNotifications] = useState<Notification[]>(DUMMY_NOTIFICATIONS)
+  const [notifications, setNotifications] = useState<Notification[]>(loadNotificationsFromStorage)
+  const [workspaces, setWorkspaces] = useState<Array<{ workspaceId: number; name: string }>>([])
+  const clientRef = useRef<Client | null>(null)
+  const subscriptionsRef = useRef<Array<{ path: string; subscription: any }>>([])
+  const workspaceMapRef = useRef<Map<number, string>>(new Map())
 
   // 사용자 프로필 이미지 로드
   useEffect(() => {
@@ -117,13 +93,304 @@ export default function NotificationPage(): JSX.Element {
     }
   }, [])
 
+  // 워크스페이스 목록 불러오기
+  useEffect(() => {
+    const fetchWorkspaces = async () => {
+      try {
+        const accessToken = localStorage.getItem('accessToken')
+        if (!accessToken) {
+          console.warn('[알림] 로그인이 필요합니다.')
+          return
+        }
+
+        console.log('[알림] 워크스페이스 목록 불러오기 시작')
+        const res = await axios.get<Array<{ workspaceId: number; name: string }>>(
+          `${API_BASE_URL}/v1/workspaces`,
+          {
+            headers: {
+              'Authorization': `Bearer ${accessToken}`
+            }
+          }
+        )
+
+        console.log('[알림] 워크스페이스 목록 불러오기 완료:', res.data.length, '개')
+        setWorkspaces(res.data)
+        // 워크스페이스 ID -> 이름 매핑 저장
+        const map = new Map<number, string>()
+        res.data.forEach(ws => {
+          map.set(ws.workspaceId, ws.name)
+          console.log('[알림] 워크스페이스 매핑:', ws.workspaceId, '->', ws.name)
+        })
+        workspaceMapRef.current = map
+      } catch (err) {
+        console.error('[알림] 워크스페이스 목록 불러오기 실패:', err)
+      }
+    }
+
+    fetchWorkspaces()
+    
+    // 주기적으로 워크스페이스 목록 갱신 (30초마다)
+    const interval = setInterval(() => {
+      fetchWorkspaces()
+    }, 30000)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [])
+
+  // WebSocket 구독 설정
+  useEffect(() => {
+    if (workspaces.length === 0) {
+      console.log('[알림 웹소켓] 워크스페이스 목록이 비어있어 구독을 건너뜁니다.')
+      return
+    }
+
+    const accessToken = localStorage.getItem('accessToken')
+    if (!accessToken) {
+      console.log('[알림 웹소켓] 액세스 토큰이 없어 구독을 건너뜁니다.')
+      return
+    }
+
+    console.log('[알림 웹소켓] 구독 설정 시작 - 워크스페이스 개수:', workspaces.length)
+    workspaces.forEach(ws => {
+      console.log('[알림 웹소켓] 워크스페이스:', ws.workspaceId, ws.name)
+    })
+
+    // 기존 연결이 있으면 정리
+    if (clientRef.current) {
+      console.log('[알림 웹소켓] 기존 연결 정리 시작')
+      if (clientRef.current.connected) {
+        subscriptionsRef.current.forEach(sub => {
+          try {
+            sub.subscription.unsubscribe()
+            console.log('[알림 웹소켓] 구독 해제:', sub.path)
+          } catch (e) {
+            console.error('[알림 웹소켓] 구독 해제 오류:', e)
+          }
+        })
+        subscriptionsRef.current = []
+      }
+      try {
+        clientRef.current.deactivate()
+        console.log('[알림 웹소켓] 기존 연결 비활성화 완료')
+      } catch (e) {
+        console.error('[알림 웹소켓] 연결 해제 오류:', e)
+      }
+    }
+
+    // STOMP 클라이언트 생성
+    const socketUrl = `${SOCKET_SERVER_URL}/ws`
+    console.log('[알림 웹소켓] 소켓 URL:', socketUrl)
+    const socket = new SockJS(socketUrl)
+    const stompClient = new Client({
+      webSocketFactory: () => socket,
+      connectHeaders: {
+        Authorization: `Bearer ${accessToken}`
+      },
+      reconnectDelay: 5000,
+      heartbeatIncoming: 4000,
+      heartbeatOutgoing: 4000,
+      debug: (str) => {
+        console.log('[알림 웹소켓] STOMP 디버그:', str)
+      },
+      onConnect: (frame) => {
+        console.log('[알림 웹소켓] 연결 성공:', frame)
+        console.log('[알림 웹소켓] 연결된 워크스페이스 개수:', workspaces.length)
+
+        // 각 워크스페이스에 대해 알림 구독
+        workspaces.forEach(workspace => {
+          const subscriptionPath = `/topic/workspace/${workspace.workspaceId}/users`
+          console.log('[알림 웹소켓] 구독 시작:', subscriptionPath)
+
+          try {
+            const subscription = stompClient.subscribe(subscriptionPath, (message) => {
+              console.log('[알림 웹소켓] 알림 수신:', message.body)
+              
+              try {
+                let data: any
+                let messageText: string = ''
+                
+                // 메시지가 JSON 형식인지 확인
+                try {
+                  data = JSON.parse(message.body)
+                  messageText = data.message || message.body
+                } catch {
+                  // JSON이 아니면 문자열로 처리
+                  messageText = message.body
+                  data = { message: messageText }
+                }
+                
+                console.log('[알림 웹소켓] 파싱된 데이터:', data)
+                console.log('[알림 웹소켓] 메시지 텍스트:', messageText)
+
+                // 현재 사용자 ID 추출
+                let currentUserId: string | null = null
+                try {
+                  const tokenPayload = JSON.parse(atob(accessToken.split('.')[1]))
+                  currentUserId = String(tokenPayload.user_id || tokenPayload.sub)
+                } catch (e) {
+                  console.warn('JWT 토큰 파싱 실패:', e)
+                }
+
+                // 자신이 발생시킨 이벤트는 무시
+                if (data.userId && String(data.userId) === currentUserId) {
+                  console.log('[알림 웹소켓] 자신의 이벤트 무시')
+                  return
+                }
+
+                // 알림 타입 확인
+                let notificationType = data.type
+                if (!notificationType) {
+                  // 메시지 내용으로 타입 추론
+                  if (messageText.includes('참여') || messageText.includes('입장')) {
+                    notificationType = 'user_joined'
+                  } else if (messageText.includes('떠났') || messageText.includes('나갔') || messageText.includes('퇴장') || messageText.includes('제거')) {
+                    notificationType = 'user_left'
+                  } else {
+                    // 기본값: 메시지가 있으면 참여로 간주
+                    notificationType = 'user_joined'
+                  }
+                }
+                const isEnter = notificationType === 'user_joined' || notificationType === 'enter'
+
+                // 워크스페이스 이름 가져오기
+                const workspaceName = workspaceMapRef.current.get(workspace.workspaceId) || workspace.name || '알 수 없는 프로젝트'
+                
+                // 사용자 이름 추출 (백엔드에서 JSON으로 보내면 우선 사용)
+                let userName = data.userName || data.name
+                if (!userName || userName === '알 수 없는 사용자') {
+                  // 메시지에서 사용자 이름 추출 시도
+                  // "사용자 {name}가 워크스페이스에 참여했습니다." 형식
+                  // "사용자 {name}가 워크스페이스를 떠났습니다." 형식
+                  // "사용자 {name}가 워크스페이스에서 제거되었습니다." 형식
+                  const match = messageText.match(/사용자\s+([^가님이]+?)(?:가|님이)/)
+                  if (match) {
+                    userName = match[1].trim()
+                  } else {
+                    // "사용자 {name}가" 형식 (더 넓은 범위)
+                    const match2 = messageText.match(/사용자\s+([^가]+)가/)
+                    if (match2) {
+                      userName = match2[1].trim()
+                    } else {
+                      // "{name}님이" 형식
+                      const match3 = messageText.match(/([^님이]+)님이/)
+                      if (match3) {
+                        userName = match3[1].trim()
+                      } else {
+                        console.warn('[알림 웹소켓] 사용자 이름 추출 실패, 메시지:', messageText)
+                        userName = '알 수 없는 사용자'
+                      }
+                    }
+                  }
+                }
+                
+                console.log('[알림 웹소켓] 추출된 사용자 이름:', userName, '원본 메시지:', messageText)
+
+                // 새 알림 생성
+                const newNotification: Notification = {
+                  id: `${workspace.workspaceId}-${Date.now()}-${Math.random()}`,
+                  projectName: workspaceName,
+                  userName: userName,
+                  timestamp: new Date(),
+                  type: isEnter ? 'enter' : 'leave',
+                  isRead: false
+                }
+
+                // 알림 목록에 추가 (항상 추가, 중복 방지는 타임스탬프 기반으로만)
+                setNotifications(prev => {
+                  // 같은 워크스페이스, 같은 사용자, 같은 타입의 매우 최근 알림(1초 이내)만 무시
+                  const veryRecent = prev.find(n => 
+                    n.projectName === newNotification.projectName &&
+                    n.userName === newNotification.userName &&
+                    n.type === newNotification.type &&
+                    Math.abs(newNotification.timestamp.getTime() - n.timestamp.getTime()) < 1000 // 1초 이내
+                  )
+                  if (veryRecent) {
+                    console.log('[알림 웹소켓] 매우 최근 중복 알림 무시 (1초 이내)')
+                    return prev
+                  }
+                  console.log('[알림 웹소켓] 새 알림 추가:', newNotification)
+                  const updated = [newNotification, ...prev]
+                  // localStorage에 저장
+                  saveNotificationsToStorage(updated)
+                  return updated
+                })
+              } catch (e) {
+                console.error('[알림 웹소켓] 메시지 파싱 오류:', e)
+                console.error('[알림 웹소켓] 원본 body:', message.body)
+              }
+            })
+
+            subscriptionsRef.current.push({ path: subscriptionPath, subscription })
+            console.log('[알림 웹소켓] 구독 완료:', subscriptionPath, '구독 ID:', subscription.id)
+          } catch (subscribeError) {
+            console.error('[알림 웹소켓] 구독 오류:', subscriptionPath, subscribeError)
+          }
+        })
+        
+        console.log('[알림 웹소켓] 총 구독 개수:', subscriptionsRef.current.length)
+        subscriptionsRef.current.forEach(sub => {
+          console.log('[알림 웹소켓] 활성 구독:', sub.path)
+        })
+      },
+      onStompError: (frame) => {
+        console.error('[알림 웹소켓] STOMP 오류:', frame)
+        console.error('[알림 웹소켓] STOMP 오류 상세:', {
+          command: frame.command,
+          headers: frame.headers,
+          body: frame.body
+        })
+      },
+      onWebSocketClose: (event) => {
+        console.log('[알림 웹소켓] WebSocket 연결 해제:', event)
+        console.log('[알림 웹소켓] 종료 코드:', event.code, '이유:', event.reason)
+      },
+      onDisconnect: () => {
+        console.log('[알림 웹소켓] STOMP 연결 끊김')
+      },
+      onWebSocketError: (event) => {
+        console.error('[알림 웹소켓] WebSocket 오류:', event)
+      }
+    })
+
+    clientRef.current = stompClient
+    console.log('[알림 웹소켓] STOMP 클라이언트 활성화 시작')
+    stompClient.activate()
+
+    // 정리 함수
+    return () => {
+      console.log('[알림 웹소켓] 정리 시작')
+      subscriptionsRef.current.forEach(sub => {
+        try {
+          sub.subscription.unsubscribe()
+        } catch (e) {
+          console.error('구독 해제 오류:', e)
+        }
+      })
+      subscriptionsRef.current = []
+      
+      if (clientRef.current) {
+        try {
+          clientRef.current.deactivate()
+        } catch (e) {
+          console.error('WebSocket 연결 해제 오류:', e)
+        }
+        clientRef.current = null
+      }
+    }
+  }, [workspaces])
+
   // 알림 클릭 시 읽음 처리
   const handleNotificationClick = (id: string) => {
-    setNotifications(prev =>
-      prev.map(notif =>
+    setNotifications(prev => {
+      const updated = prev.map(notif =>
         notif.id === id ? { ...notif, isRead: true } : notif
       )
-    )
+      // localStorage에 저장
+      saveNotificationsToStorage(updated)
+      return updated
+    })
   }
 
   // 최신순으로 정렬된 알림


### PR DESCRIPTION
### 변경사항

알림 페이지와 메인 사이드바를 연동하여, 워크스페이스 활동 알림을 실시간으로 받아보고 히스토리로 관리할 수 있도록 개선했습니다.

**프론트엔드 변경사항:**

1. **알림 페이지 WebSocket 구독 및 알림 표시 (`NotificationPage`)**
   - `/v1/workspaces` API로 사용자가 속한 워크스페이스 목록을 조회한 뒤, 각 워크스페이스의 `/topic/workspace/{workspaceId}/users` 토픽을 STOMP WebSocket으로 구독합니다.
   - 백엔드에서 전송하는 JSON 형식 알림(`type`, `userId`, `userName`, `message`)과 단순 문자열 메시지를 모두 처리할 수 있도록 파싱 로직을 구현했습니다.
   - 현재 로그인한 사용자가 보낸 이벤트(`data.userId === currentUserId`)는 알림 카드로 만들지 않고 무시하여 중복 표시를 방지합니다.
   - 입장/퇴장/제거 메시지를 기준으로 `enter`/`leave` 타입을 결정하여 UI에 “입장했습니다 / 퇴장했습니다”로 일관되게 표시합니다.

2. **알림 localStorage 저장 및 복원**
   - `loadNotificationsFromStorage` / `saveNotificationsToStorage` 유틸을 추가하여 알림 목록을 `localStorage.notifications`에 JSON으로 저장합니다.
   - 새로고침 후에도 이전 알림들이 그대로 복원되며, `timestamp`는 `Date` 객체로 복원해 “방금 전 / n분 전 / n시간 전” 포맷에 사용합니다.
   - 알림 카드 클릭 시 `isRead` 플래그를 변경하고, 해당 상태도 localStorage에 함께 반영하여 읽음 상태가 유지되도록 했습니다.
   - 동일 워크스페이스/사용자/타입에 대해 1초 이내에 반복되는 알림만 중복으로 간주하고 무시하여, 실시간 이벤트가 몰릴 때 불필요한 카드가 쌓이지 않도록 했습니다.

3. **사이드바 사용자 정보 및 레이아웃 복원 (`Sidebar`)**
   - `/v1/users/me` API와 `localStorage`를 조합하여 사용자 이름/이메일/프로필 이미지를 로딩하고, 이름에서 이니셜(`getInitials`)을 계산해 아바타에 표시합니다.
   - API 요청 실패 시에도 `localStorage.userName`을 기반으로 최소한의 사용자 정보를 유지하고, 401/403 응답 시에는 토큰과 사용자 정보를 제거한 뒤 페이지를 새로고침하여 재로그인을 유도합니다.
   - 상단 메뉴: **홈 / 알림 / 즐겨찾기**  
     하단 메뉴: **휴지통 / 설정 / 로그아웃**  
     구조로 레이아웃을 원래대로 복원했습니다.
   - 알림 메뉴에는 `unreadNotifications` prop을 통해 빨간 배지(동그라미)를 표시하도록 했습니다.

---

### 테스트

- [ ] 테스트 코드
- [x] 수동 UI 테스트

**수동 테스트 시나리오:**

1. 브라우저 A/B 두 개를 열고 서로 다른 계정 또는 초대 수락 플로우를 사용해 동일 워크스페이스에 접속합니다.
2. 브라우저 B에서 워크스페이스 입장/퇴장/제거(OWNER에 의한 제거 포함)를 여러 번 시도합니다.
3. 브라우저 A의 `/notifications` 페이지에서:
   - 실시간으로 새로운 알림 카드가 추가되는지,
   - 사용자 이름/워크스페이스 이름/입장/퇴장 라벨이 올바르게 표시되는지 확인합니다.
4. 알림 카드를 클릭해 읽음 처리 후, 페이지를 새로고침해도 읽음 상태와 기존 알림 목록이 유지되는지 확인합니다.
5. 메인 페이지와 설정 페이지에서 사이드바:
   - 상단에 실제 사용자 이름과 이니셜/프로필이 표시되는지,
   - 하단에 휴지통/설정/로그아웃이 항상 정렬되어 있는지 확인합니다.