### PR TITLE
Feat/prd production polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,10 @@
         "lucide-react": "^0.554.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.9.3",
+        "rehype-sanitize": "^6.0.0",
+        "remark-gfm": "^4.0.1",
         "socket.io-client": "^4.8.1",
         "sockjs-client": "^1.6.1"
       },
@@ -1461,18 +1464,64 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1489,11 +1538,16 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -7033,6 +7087,16 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/base64-arraybuffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
@@ -7175,6 +7239,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7249,6 +7323,46 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -7416,6 +7530,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
@@ -7509,14 +7633,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7530,6 +7652,19 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -7537,6 +7672,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/didyoumean": {
@@ -9277,6 +9434,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -9295,6 +9462,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -9801,6 +9974,71 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -9846,6 +10084,46 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -9869,6 +10147,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -9877,6 +10165,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jiti": {
@@ -11342,6 +11642,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -11369,6 +11679,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -11377,6 +11697,851 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -13222,6 +14387,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -13563,6 +14753,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -13598,6 +14798,33 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
       }
     },
     "node_modules/react-refresh": {
@@ -13646,6 +14873,86 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/requires-port": {
@@ -13841,6 +15148,16 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -16524,6 +17841,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -16545,6 +17876,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -17260,6 +18609,113 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -17277,6 +18733,34 @@
       "license": "MIT",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -17369,13 +18853,6 @@
       "os": [
         "darwin"
       ]
-    },
-    "node_modules/vite/node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vite/node_modules/esbuild": {
       "version": "0.21.5",
@@ -17508,6 +18985,16 @@
       "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "lucide-react": "^0.554.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.9.3",
+    "rehype-sanitize": "^6.0.0",
+    "remark-gfm": "^4.0.1",
     "socket.io-client": "^4.8.1",
     "sockjs-client": "^1.6.1"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ function App() {
         <Route path="/canvas" element={<InfiniteCanvasPage />} />
         <Route path="/prd" element={<PRDPage />} />
         <Route path="/prd/result/:id" element={<PRDResultPage />} />
+        <Route path="/prd/workspaces/:workspaceId/prds/:prdId" element={<PRDResultPage />} />
         <Route path="/trash" element={<TrashPage />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/notifications" element={<NotificationPage />} />

--- a/src/components/PRDGeneratorModal/PRDGeneratorModal.module.css
+++ b/src/components/PRDGeneratorModal/PRDGeneratorModal.module.css
@@ -553,3 +553,11 @@
   font-family: inherit;
   overflow-x: auto;
 }
+
+.prdMarkdownDoc {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 12px 14px 16px;
+  max-width: 100%;
+}

--- a/src/components/PRDGeneratorModal/PRDGeneratorModal.tsx
+++ b/src/components/PRDGeneratorModal/PRDGeneratorModal.tsx
@@ -7,6 +7,8 @@ import {
   Code2, TrendingUp, Shield, Clock
 } from 'lucide-react'
 import axios from 'axios'
+import { PrdCompletionPanel } from '../prd/PrdCompletionPanel'
+import { PrdMarkdownBody } from '../prd/PrdMarkdownBody'
 import { API_BASE_URL } from '../../config/api'
 import styles from './PRDGeneratorModal.module.css'
 
@@ -15,7 +17,20 @@ import styles from './PRDGeneratorModal.module.css'
 interface IdeaCard { id: string | number; text: string; selected: boolean }
 type TabId = 'prd' | 'spec' | 'flow'
 type GenState = 'idle' | 'loading' | 'done' | 'error'
-interface PRDResult { projectName: string; cards: string[]; generatedAt: string; prdMarkdown?: string }
+interface PRDResult {
+  projectName: string
+  cards: string[]
+  generatedAt: string
+  prdMarkdown?: string
+  vercelPreviewUrl?: string
+  vercelProductionUrl?: string
+  githubRepoUrl?: string
+  ideaId?: number
+  jobId?: number
+  workspaceId?: number
+  prdViewUrl?: string
+  prdViewPath?: string
+}
 
 const STEPS = ['아이디어 카드 분석 중...', 'AI가 내용을 이해하는 중...', 'PRD 구조 설계 중...', '문서 작성 중...', '완료']
 
@@ -101,7 +116,15 @@ function EmptyPanel() {
 }
 
 function PRDTab({ result }: { result: PRDResult }) {
-  if (result.prdMarkdown) return <div className={styles.tabContent}><pre className={styles.markdownBlock}>{result.prdMarkdown}</pre></div>
+  if (result.prdMarkdown) {
+    return (
+      <div className={styles.tabContent}>
+        <div className={styles.prdMarkdownDoc}>
+          <PrdMarkdownBody markdown={result.prdMarkdown} />
+        </div>
+      </div>
+    )
+  }
   const { features } = makePRD(result.projectName, result.cards)
   return (
     <div className={styles.tabContent}>
@@ -289,10 +312,55 @@ export default function PRDGeneratorModal({ isOpen, workspaceId, projectName, on
           await new Promise(r => setTimeout(r, 2000))
           const poll = await axios.get(`${API_BASE_URL}/v1/ideas/${ideaId}/prototype/jobs/${jobId}`, { headers })
           if (poll.data.status === 'FAILED') throw new Error(poll.data.message || 'PRD 생성 실패')
-          if (['DEPLOYED', 'PRD_GENERATED', 'UI_GENERATED', 'CODE_GENERATED', 'GITHUB_PUSHED'].includes(poll.data.status)) {
+          const isDeployed = poll.data.status === 'DEPLOYED'
+          const fallbackReady =
+            i >= 60 &&
+            ['PRD_GENERATED', 'UI_GENERATED', 'CODE_GENERATED', 'GITHUB_PUSHED'].includes(
+              poll.data.status
+            ) &&
+            Boolean((poll.data.prdMarkdown || '').trim())
+          if (isDeployed || fallbackReady) {
             clearInterval(timer); setGenStep(STEPS.length - 1)
-            setResult({ projectName, cards: selected.map(c => c.text), generatedAt: new Date().toLocaleDateString('ko-KR'), prdMarkdown: poll.data.prdMarkdown || undefined })
-            setGenState('done'); return
+            const p = poll.data as {
+              prdMarkdown?: string
+              prdViewUrl?: string
+              prdViewPath?: string
+              workspaceId?: number
+              ideaId?: number
+              jobId?: number
+              vercelPreviewUrl?: string
+              vercelProductionUrl?: string
+              githubRepoUrl?: string
+            }
+            const wsNum = Number(workspaceId)
+            const ws = p.workspaceId ?? (Number.isFinite(wsNum) ? wsNum : undefined)
+            const jid = p.jobId ?? jobId
+            setResult({
+              projectName,
+              cards: selected.map(c => c.text),
+              generatedAt: new Date().toLocaleDateString('ko-KR'),
+              prdMarkdown: p.prdMarkdown || undefined,
+              prdViewUrl: p.prdViewUrl || undefined,
+              prdViewPath: p.prdViewPath || undefined,
+              ideaId: p.ideaId ?? ideaId,
+              jobId: jid,
+              workspaceId: ws,
+              vercelPreviewUrl: p.vercelPreviewUrl || undefined,
+              vercelProductionUrl: p.vercelProductionUrl || undefined,
+              githubRepoUrl: p.githubRepoUrl || undefined,
+            })
+            setGenState('done')
+            const toOpen =
+              (typeof p.prdViewUrl === 'string' && p.prdViewUrl.trim()) ||
+              (p.prdViewPath &&
+                `${window.location.origin}${p.prdViewPath.startsWith('/') ? '' : '/'}${p.prdViewPath}`) ||
+              (ws != null && jid != null
+                ? `${window.location.origin}/prd/workspaces/${ws}/prds/${jid}`
+                : '')
+            if (toOpen) {
+              window.open(toOpen, '_blank', 'noopener,noreferrer')
+            }
+            return
           }
         }
         throw new Error('시간 초과: 잠시 후 다시 시도해주세요')
@@ -376,6 +444,17 @@ export default function PRDGeneratorModal({ isOpen, workspaceId, projectName, on
             )}
             {genState === 'done' && result && (
               <div className={styles.resultWrap}>
+                {((result.workspaceId != null && result.jobId != null) || result.prdViewUrl) && (
+                  <PrdCompletionPanel
+                    info={{
+                      workspaceId: result.workspaceId,
+                      jobId: result.jobId,
+                      ideaId: result.ideaId,
+                      prdViewUrl: result.prdViewUrl,
+                      prdViewPath: result.prdViewPath,
+                    }}
+                  />
+                )}
                 <div className={styles.tabBar}>
                   {TABS.map(tab => {
                     const Icon = tab.icon

--- a/src/components/PRDModal/PRDModal.module.css
+++ b/src/components/PRDModal/PRDModal.module.css
@@ -485,6 +485,15 @@
   margin: 0;
 }
 
+/* API PRD 마크다운(렌더된 본문) */
+.prdMarkdownDoc {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 12px 14px 16px;
+  max-width: 100%;
+}
+
 /* spec table */
 .specTable { display: flex; flex-direction: column; gap: 0; border: 1px solid #f0f0f0; border-radius: 8px; overflow: hidden; }
 .specTableHead {

--- a/src/components/PRDModal/PRDModal.tsx
+++ b/src/components/PRDModal/PRDModal.tsx
@@ -8,6 +8,8 @@ import {
 } from 'lucide-react'
 import axios from 'axios'
 import { usePRDModal } from '../../context/PRDModalContext'
+import { PrdCompletionPanel } from '../prd/PrdCompletionPanel'
+import { PrdMarkdownBody } from '../prd/PrdMarkdownBody'
 import { API_BASE_URL } from '../../config/api'
 import styles from './PRDModal.module.css'
 
@@ -27,6 +29,14 @@ interface PRDResult {
   cards: string[]
   generatedAt: string
   prdMarkdown?: string
+  vercelPreviewUrl?: string
+  vercelProductionUrl?: string
+  githubRepoUrl?: string
+  ideaId?: number
+  jobId?: number
+  workspaceId?: number
+  prdViewUrl?: string
+  prdViewPath?: string
 }
 
 const STEPS = [
@@ -133,7 +143,13 @@ const TABS: { id: TabId; label: string; icon: typeof FileText }[] = [
 
 function PRDTab({ result }: { result: PRDResult }) {
   if (result.prdMarkdown) {
-    return <div className={styles.tabContent}><pre className={styles.markdownBlock}>{result.prdMarkdown}</pre></div>
+    return (
+      <div className={styles.tabContent}>
+        <div className={styles.prdMarkdownDoc}>
+          <PrdMarkdownBody markdown={result.prdMarkdown} />
+        </div>
+      </div>
+    )
   }
   const { features } = makePRD(result.projectName, result.cards)
   return (
@@ -340,11 +356,55 @@ export default function PRDModal() {
           await new Promise(r => setTimeout(r, 2000))
           const poll = await axios.get(`${API_BASE_URL}/v1/ideas/${ideaId}/prototype/jobs/${jobId}`, { headers })
           if (poll.data.status === 'FAILED') throw new Error(poll.data.message || 'PRD 생성 실패')
-          if (['DEPLOYED', 'PRD_GENERATED', 'UI_GENERATED', 'CODE_GENERATED', 'GITHUB_PUSHED'].includes(poll.data.status)) {
+          const isDeployed = poll.data.status === 'DEPLOYED'
+          const fallbackReady =
+            i >= 60 &&
+            ['PRD_GENERATED', 'UI_GENERATED', 'CODE_GENERATED', 'GITHUB_PUSHED'].includes(
+              poll.data.status
+            ) &&
+            Boolean((poll.data.prdMarkdown || '').trim())
+          if (isDeployed || fallbackReady) {
             clearInterval(stepTimer)
             setGenStep(STEPS.length - 1)
-            setResult({ projectName, cards: selected.map(c => c.text), generatedAt: new Date().toLocaleDateString('ko-KR'), prdMarkdown: poll.data.prdMarkdown || undefined })
+            const p = poll.data as {
+              prdMarkdown?: string
+              prdViewUrl?: string
+              prdViewPath?: string
+              workspaceId?: number
+              ideaId?: number
+              jobId?: number
+              vercelPreviewUrl?: string
+              vercelProductionUrl?: string
+              githubRepoUrl?: string
+            }
+            const wsNum = Number(workspaceId)
+            const ws = p.workspaceId ?? (Number.isFinite(wsNum) ? wsNum : undefined)
+            const jid = p.jobId ?? jobId
+            setResult({
+              projectName,
+              cards: selected.map(c => c.text),
+              generatedAt: new Date().toLocaleDateString('ko-KR'),
+              prdMarkdown: p.prdMarkdown || undefined,
+              prdViewUrl: p.prdViewUrl || undefined,
+              prdViewPath: p.prdViewPath || undefined,
+              ideaId: p.ideaId ?? ideaId,
+              jobId: jid,
+              workspaceId: ws,
+              vercelPreviewUrl: p.vercelPreviewUrl || undefined,
+              vercelProductionUrl: p.vercelProductionUrl || undefined,
+              githubRepoUrl: p.githubRepoUrl || undefined,
+            })
             setGenState('done')
+            const toOpen =
+              (typeof p.prdViewUrl === 'string' && p.prdViewUrl.trim()) ||
+              (p.prdViewPath &&
+                `${window.location.origin}${p.prdViewPath.startsWith('/') ? '' : '/'}${p.prdViewPath}`) ||
+              (ws != null && jid != null
+                ? `${window.location.origin}/prd/workspaces/${ws}/prds/${jid}`
+                : '')
+            if (toOpen) {
+              window.open(toOpen, '_blank', 'noopener,noreferrer')
+            }
             return
           }
         }
@@ -445,6 +505,17 @@ export default function PRDModal() {
             )}
             {genState === 'done' && result && (
               <div className={styles.resultWrap} ref={resultRef}>
+                {((result.workspaceId != null && result.jobId != null) || result.prdViewUrl) && (
+                  <PrdCompletionPanel
+                    info={{
+                      workspaceId: result.workspaceId,
+                      jobId: result.jobId,
+                      ideaId: result.ideaId,
+                      prdViewUrl: result.prdViewUrl,
+                      prdViewPath: result.prdViewPath,
+                    }}
+                  />
+                )}
                 <div className={styles.tabBar}>
                   {TABS.map(tab => {
                     const Icon = tab.icon

--- a/src/components/prd/PrdCompletionPanel.module.css
+++ b/src/components/prd/PrdCompletionPanel.module.css
@@ -1,0 +1,136 @@
+.wrap {
+  margin-bottom: 20px;
+  padding: 16px 18px;
+  border: 1px solid #c7f5d0;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #f0fdf4 0%, #fff 100%);
+}
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.titleIcon {
+  color: #01cd15;
+}
+.title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+.lead {
+  margin: 0 0 12px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #64748b;
+}
+.urlRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.urlText {
+  flex: 1 1 200px;
+  font-size: 0.8rem;
+  padding: 8px 10px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  word-break: break-all;
+  color: #0f172a;
+}
+.iconBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  cursor: pointer;
+  color: #475569;
+}
+.iconBtn:hover {
+  background: #f8fafc;
+}
+.primaryBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 8px;
+  border: none;
+  background: #01cd15;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.primaryBtn:hover {
+  filter: brightness(0.95);
+}
+.previewHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.previewLabel {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #334155;
+}
+.ghostBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 0.8rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  color: #64748b;
+}
+.ghostBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.spin {
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.iframeShell {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #fff;
+}
+.iframe {
+  width: 100%;
+  min-height: 360px;
+  border: none;
+  display: block;
+}
+.previewLoading {
+  font-size: 0.85rem;
+  color: #64748b;
+  padding: 12px 0;
+}
+.previewError {
+  font-size: 0.85rem;
+  color: #b45309;
+  padding: 10px 12px;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 8px;
+}

--- a/src/components/prd/PrdCompletionPanel.tsx
+++ b/src/components/prd/PrdCompletionPanel.tsx
@@ -1,0 +1,147 @@
+import { useState, useEffect, useCallback } from 'react'
+import axios from 'axios'
+import { ExternalLink, Copy, Check, RefreshCw, Globe } from 'lucide-react'
+import { API_BASE_URL } from '../../config/api'
+import styles from './PrdCompletionPanel.module.css'
+
+export type PrdCompletionInfo = {
+  workspaceId?: number
+  jobId?: number
+  ideaId?: number
+  prdViewUrl?: string
+  prdViewPath?: string
+}
+
+type Props = {
+  info: PrdCompletionInfo | null
+}
+
+function buildOpenUrl(info: PrdCompletionInfo | null): string | null {
+  if (!info) return null
+  const u = info.prdViewUrl?.trim()
+  if (u) return u
+  const p = info.prdViewPath?.trim()
+  if (p) {
+    if (p.startsWith('http')) return p
+    return `${window.location.origin}${p.startsWith('/') ? '' : '/'}${p}`
+  }
+  if (info.workspaceId != null && info.jobId != null) {
+    return `${window.location.origin}/prd/workspaces/${info.workspaceId}/prds/${info.jobId}`
+  }
+  return null
+}
+
+export function PrdCompletionPanel({ info }: Props) {
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+  const [loadingPreview, setLoadingPreview] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const openUrl = buildOpenUrl(info)
+
+  const loadPreview = useCallback(async () => {
+    if (info?.workspaceId == null || info?.jobId == null) {
+      setPreviewHtml(null)
+      setPreviewError('워크스페이스·작업 ID가 없어 프리뷰를 불러올 수 없습니다.')
+      return
+    }
+    const token = localStorage.getItem('accessToken')
+    if (!token) {
+      setPreviewError('로그인이 필요해 프리뷰를 불러올 수 없습니다.')
+      return
+    }
+    setLoadingPreview(true)
+    setPreviewError(null)
+    try {
+      const { data } = await axios.get(
+        `${API_BASE_URL}/v1/workspaces/${info.workspaceId}/prds/${info.jobId}/preview`,
+        { headers: { Authorization: `Bearer ${token}` }, responseType: 'text' }
+      )
+      setPreviewHtml(typeof data === 'string' ? data : null)
+    } catch {
+      setPreviewHtml(null)
+      setPreviewError('미리보기를 불러오지 못했습니다. 잠시 후 새로고침 해 보세요.')
+    } finally {
+      setLoadingPreview(false)
+    }
+  }, [info?.workspaceId, info?.jobId])
+
+  useEffect(() => {
+    if (info?.workspaceId != null && info?.jobId != null) {
+      void loadPreview()
+    } else {
+      setPreviewHtml(null)
+      setPreviewError(null)
+    }
+  }, [info?.workspaceId, info?.jobId, loadPreview])
+
+  if (!info || (openUrl == null && info.workspaceId == null)) {
+    return null
+  }
+
+  function copyUrl() {
+    if (!openUrl) return
+    void navigator.clipboard.writeText(openUrl).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  function openInNewTab() {
+    if (!openUrl) return
+    window.open(openUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <div className={styles.wrap}>
+      <div className={styles.titleRow}>
+        <Globe size={18} className={styles.titleIcon} />
+        <h3 className={styles.title}>PRD가 준비되었어요</h3>
+      </div>
+      <p className={styles.lead}>
+        아래 링크로 팀과 같은 PRD·미리보기 화면을 열 수 있어요. 새 탭이 뜨지 않았다면 버튼을 눌러 주세요.
+      </p>
+      {openUrl && (
+        <div className={styles.urlRow}>
+          <code className={styles.urlText}>{openUrl}</code>
+          <button type="button" className={styles.iconBtn} onClick={copyUrl} title="URL 복사">
+            {copied ? <Check size={16} /> : <Copy size={16} />}
+          </button>
+          <button type="button" className={styles.primaryBtn} onClick={openInNewTab}>
+            <ExternalLink size={15} />
+            새 탭에서 열기
+          </button>
+        </div>
+      )}
+
+      <div className={styles.previewHead}>
+        <span className={styles.previewLabel}>화면 미리보기</span>
+        <button
+          type="button"
+          className={styles.ghostBtn}
+          onClick={() => void loadPreview()}
+          disabled={loadingPreview}
+        >
+          <RefreshCw size={14} className={loadingPreview ? styles.spin : ''} />
+          새로고침
+        </button>
+      </div>
+      {loadingPreview && !previewHtml && !previewError && (
+        <div className={styles.previewLoading}>프리뷰 불러오는 중…</div>
+      )}
+      {previewHtml && (
+        <div className={styles.iframeShell}>
+          <iframe
+            title="prototype-preview"
+            srcDoc={previewHtml}
+            sandbox="allow-scripts allow-same-origin"
+            className={styles.iframe}
+          />
+        </div>
+      )}
+      {previewError && (
+        <div className={styles.previewError}>{previewError}</div>
+      )}
+    </div>
+  )
+}

--- a/src/components/prd/PrdMarkdownBody.module.css
+++ b/src/components/prd/PrdMarkdownBody.module.css
@@ -1,0 +1,244 @@
+/* PRD 본문 — 인쇄/문서 읽기에 맞춘 타이포그래피 (GFM: 표, 체크리스트) */
+
+.root {
+  --prd-text: #0f172a;
+  --prd-border: #e2e8f0;
+  --prd-surface: #fff;
+  --prd-code-bg: #f1f5f9;
+  --prd-pre-bg: #0f172a;
+  --prd-pre-fg: #e2e8f0;
+  --prd-accent: #059669;
+  --prd-radius: 10px;
+  --prd-prose: clamp(0.9rem, 0.2vw + 0.86rem, 1rem);
+
+  margin: 0 auto;
+  max-width: 48rem;
+  padding: 0;
+  color: var(--prd-text);
+  font-size: var(--prd-prose);
+  line-height: 1.75;
+  font-family: 'Pretendard', 'Apple SD Gothic Neo', 'Noto Sans KR', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  letter-spacing: -0.01em;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
+.root :global {
+  h1 {
+    margin: 0 0 0.5rem;
+    font-size: clamp(1.35rem, 2vw, 1.6rem);
+    font-weight: 800;
+    line-height: 1.3;
+    color: #020617;
+    letter-spacing: -0.02em;
+    padding-bottom: 0.6rem;
+    border-bottom: 1px solid var(--prd-border);
+  }
+  h2 {
+    margin: 2.25rem 0 0.75rem;
+    font-size: 1.2rem;
+    font-weight: 800;
+    line-height: 1.35;
+    color: #0f172a;
+    padding-left: 0.6rem;
+    border-left: 3px solid var(--prd-accent);
+  }
+  h2:first-of-type {
+    margin-top: 0;
+  }
+  h3 {
+    margin: 1.5rem 0 0.5rem;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #1e293b;
+  }
+  h4,
+  h5,
+  h6 {
+    margin: 1.1rem 0 0.4rem;
+    font-size: 0.98rem;
+    font-weight: 700;
+    color: #334155;
+  }
+  p {
+    margin: 0.65rem 0 0;
+  }
+  p + p,
+  p + ul,
+  p + ol,
+  p + .tableScroll {
+    margin-top: 0.75rem;
+  }
+  strong {
+    font-weight: 700;
+    color: #0f172a;
+  }
+  em {
+    font-style: normal;
+    font-weight: 500;
+    color: #1e3a2f;
+  }
+  a {
+    color: #047857;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+  a:hover {
+    color: #065f46;
+  }
+  hr {
+    margin: 2rem 0;
+    border: none;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, #e2e8f0 8%, #e2e8f0 92%, transparent);
+  }
+  blockquote {
+    margin: 0.9rem 0 0;
+    padding: 0.65rem 0 0.65rem 1rem;
+    border-left: 3px solid #94a3b8;
+    background: #f8fafc;
+    border-radius: 0 8px 8px 0;
+    color: #475569;
+  }
+  blockquote p {
+    margin: 0;
+  }
+  blockquote p + p {
+    margin-top: 0.5rem;
+  }
+  ul,
+  ol {
+    margin: 0.5rem 0 0 0;
+    padding-left: 1.35rem;
+  }
+  li {
+    margin: 0.35rem 0;
+  }
+  li::marker {
+    color: #94a3b8;
+  }
+  li > p {
+    margin: 0.15rem 0 0;
+  }
+  ul.contains-task-list {
+    list-style: none;
+    padding-left: 0.2rem;
+  }
+  .task-list-item {
+    list-style: none;
+    position: relative;
+    padding-left: 1.5rem;
+  }
+  .task-list-item input[type='checkbox'] {
+    position: absolute;
+    left: 0;
+    top: 0.35em;
+  }
+  p code,
+  li code,
+  td code,
+  th code,
+  a code,
+  h1 code,
+  h2 code,
+  h3 code {
+    font-size: 0.88em;
+    padding: 0.12em 0.4em;
+    border-radius: 4px;
+    background: var(--prd-code-bg);
+    border: 1px solid #e2e8f0;
+    font-family: 'JetBrains Mono', 'D2Coding', 'Consolas', monospace;
+    font-weight: 500;
+  }
+  pre {
+    margin: 0.85rem 0 0;
+    padding: 1rem 1.1rem;
+    background: var(--prd-pre-bg);
+    color: var(--prd-pre-fg);
+    border-radius: var(--prd-radius);
+    font-size: 0.86rem;
+    line-height: 1.6;
+    overflow: auto;
+    border: 1px solid #1e293b;
+  }
+  pre code {
+    display: block;
+    padding: 0 !important;
+    background: none !important;
+    border: none !important;
+    font-size: inherit;
+    font-family: 'JetBrains Mono', 'D2Coding', 'Consolas', monospace;
+  }
+  img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+    border: 1px solid var(--prd-border);
+    margin: 0.8rem 0 0;
+  }
+  del {
+    color: #94a3b8;
+  }
+}
+
+/* 표 래퍼 (모듈 클래스 — TSX에서 styles.tableScroll) */
+.tableScroll {
+  margin: 0.9rem 0 0;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  border-radius: 8px;
+  border: 1px solid var(--prd-border, #e2e8f0);
+  background: #fff;
+}
+
+.tableScroll :global(table) {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.tableScroll :global(thead th) {
+  background: linear-gradient(180deg, #f8fafc, #f1f5f9);
+  font-weight: 700;
+  color: #0f172a;
+  text-align: left;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.tableScroll :global(th),
+.tableScroll :global(td) {
+  padding: 0.55rem 0.7rem;
+  border-bottom: 1px solid #e2e8f0;
+  vertical-align: top;
+}
+
+.tableScroll :global(tr:last-child td) {
+  border-bottom: none;
+}
+
+.tableScroll :global(tbody tr:nth-child(even) td) {
+  background: #fafbfc;
+}
+
+.tableScroll :global(tbody tr:hover td) {
+  background: #f0fdf4;
+}
+
+@media (max-width: 600px) {
+  .root {
+    font-size: 0.9rem;
+  }
+  .root :global(h2) {
+    font-size: 1.1rem;
+  }
+  .tableScroll :global(th),
+  .tableScroll :global(td) {
+    font-size: 0.8rem;
+    padding: 0.45rem 0.5rem;
+  }
+}

--- a/src/components/prd/PrdMarkdownBody.tsx
+++ b/src/components/prd/PrdMarkdownBody.tsx
@@ -1,0 +1,52 @@
+import ReactMarkdown, { type Components } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import rehypeSanitize from 'rehype-sanitize'
+import styles from './PrdMarkdownBody.module.css'
+
+type Props = {
+  markdown: string
+  className?: string
+}
+
+const mdComponents: Partial<Components> = {
+  a: (props) => {
+    const { href, children, node: _n, ...rest } = props
+    const h = href ?? ''
+    const isExternal = /^https?:\/\//i.test(h)
+    return (
+      <a
+        href={h}
+        {...rest}
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noopener noreferrer' : undefined}
+      >
+        {children}
+      </a>
+    )
+  },
+  table: (props) => {
+    const { children, node: _n, ...rest } = props
+    return (
+      <div className={styles.tableScroll}>
+        <table {...rest}>{children}</table>
+      </div>
+    )
+  },
+}
+
+/**
+ * API에서 내려온 PRD 마크다운 — 표·체크리스트·코드 등 GFM을 문서형으로 렌더링
+ */
+export function PrdMarkdownBody({ markdown, className }: Props) {
+  return (
+    <article className={`${styles.root} ${className || ''}`.trim()}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeSanitize]}
+        components={mdComponents}
+      >
+        {markdown}
+      </ReactMarkdown>
+    </article>
+  )
+}

--- a/src/hooks/usePRDGeneration.ts
+++ b/src/hooks/usePRDGeneration.ts
@@ -10,7 +10,14 @@ import { useState, useCallback } from 'react'
 import axios from 'axios'
 import { API_BASE_URL } from '../config/api'
 import { PRD_PIPELINE_IDEA_PREFIX, isPrdPipelineIdeaContent } from '../constants/prd'
-import type { PRDModalStatus, PRDModalStep } from '../components/PRDModal/PRDModal'
+
+type PRDModalStatus = 'idle' | 'loading' | 'success' | 'error'
+
+interface PRDModalStep {
+  label: string
+  done: boolean
+  active: boolean
+}
 
 const BASE_STEPS: string[] = [
   '카드 아이디어 수집 중...',
@@ -31,6 +38,10 @@ type PrototypeJobStatus =
   | 'FAILED'
 
 interface PrototypePipelineResponse {
+  workspaceId?: number
+  prdViewPath?: string | null
+  /** 백엔드가 설정한 SPA 풀 URL (app.prd-public-base-url) */
+  prdViewUrl?: string | null
   jobId: number
   ideaId: number
   status: PrototypeJobStatus
@@ -224,8 +235,9 @@ async function runPrototypePipeline(
     if (data.status === 'DEPLOYED') {
       return data
     }
-    // 배포 단계가 길거나 교착일 때: PRD Markdown 이 채워졌으면 여기서 완료 (무한 로딩 방지)
+    // 너무 오래 걸릴 때만 PRD만으로 우선 완료 처리 (링크 누락 방지 위해 충분히 기다림)
     if (
+      attempt >= 60 &&
       hasRenderablePrd(data) &&
       (data.status === 'PRD_GENERATED' ||
         data.status === 'UI_GENERATED' ||
@@ -342,7 +354,17 @@ export function usePRDGeneration() {
         }))
       })
 
-      const resultPageUrl = `${window.location.origin}/prd/result/ws_${workspaceId}`
+      const fromApi =
+        typeof result.prdViewUrl === 'string' && result.prdViewUrl.trim().length > 0
+          ? result.prdViewUrl.trim()
+          : ''
+      const resultPagePath =
+        result.prdViewPath ||
+        `/prd/workspaces/${workspaceId}/prds/${result.jobId}`
+      const resultPageUrl = fromApi
+        || (resultPagePath.startsWith('http')
+          ? resultPagePath
+          : `${window.location.origin}${resultPagePath.startsWith('/') ? '' : '/'}${resultPagePath}`)
       const { url: deployedUrl, usingFallback } = pickDeployedUrl(result, resultPageUrl)
 
       const prdKey = `prd_ws_${workspaceId}`

--- a/src/pages/PRDPage/PRDPage.module.css
+++ b/src/pages/PRDPage/PRDPage.module.css
@@ -838,3 +838,11 @@
   font-family: 'Pretendard', 'Noto Sans KR', sans-serif;
   overflow-x: auto;
 }
+
+.prdMarkdownDoc {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 16px 18px 20px;
+  max-width: 100%;
+}

--- a/src/pages/PRDPage/PRDPage.tsx
+++ b/src/pages/PRDPage/PRDPage.tsx
@@ -9,6 +9,8 @@ import {
 } from 'lucide-react'
 import axios from 'axios'
 import Sidebar from '../MainPage/components/Sidebar/Sidebar'
+import { PrdCompletionPanel } from '../../components/prd/PrdCompletionPanel'
+import { PrdMarkdownBody } from '../../components/prd/PrdMarkdownBody'
 import { API_BASE_URL } from '../../config/api'
 import styles from './PRDPage.module.css'
 
@@ -29,6 +31,14 @@ interface PRDResult {
   cards: string[]
   generatedAt: string
   prdMarkdown?: string
+  vercelPreviewUrl?: string
+  vercelProductionUrl?: string
+  githubRepoUrl?: string
+  ideaId?: number
+  jobId?: number
+  workspaceId?: number
+  prdViewUrl?: string
+  prdViewPath?: string
 }
 
 // ─── Loading steps ────────────────────────────────────────────────────────────
@@ -179,7 +189,9 @@ function PRDTab({ result }: { result: PRDResult }) {
   if (result.prdMarkdown) {
     return (
       <div className={styles.tabContent}>
-        <pre className={styles.markdownBlock}>{result.prdMarkdown}</pre>
+        <div className={styles.prdMarkdownDoc}>
+          <PrdMarkdownBody markdown={result.prdMarkdown} />
+        </div>
       </div>
     )
   }
@@ -343,7 +355,9 @@ const TABS: { id: TabId; label: string; icon: typeof FileText }[] = [
 
 export default function PRDPage() {
   const [searchParams] = useSearchParams()
-  const workspaceId = searchParams.get('workspaceId')
+  const workspaceIdRaw = searchParams.get('workspaceId')
+  const workspaceIdNum = workspaceIdRaw ? Number(workspaceIdRaw) : NaN
+  const workspaceId = Number.isFinite(workspaceIdNum) && workspaceIdNum > 0 ? workspaceIdNum : null
   const projectName = searchParams.get('projectName') || '내 프로젝트'
 
   const [cards, setCards] = useState<IdeaCard[]>([])
@@ -370,7 +384,7 @@ export default function PRDPage() {
 
   useEffect(() => {
     async function load() {
-      if (!workspaceId) {
+      if (workspaceId == null) {
         setCards(DEMO_CARDS.map(c => ({ ...c, selected: true })))
         return
       }
@@ -435,7 +449,7 @@ export default function PRDPage() {
     }, 900)
 
     try {
-      if (workspaceId) {
+      if (workspaceId != null) {
         // Real API flow
         const token = localStorage.getItem('accessToken')
         const headers = token ? { Authorization: `Bearer ${token}` } : {}
@@ -444,7 +458,7 @@ export default function PRDPage() {
         const body = selected.map((c, i) => `### 카드 ${i + 1}\n${c.text}`).join('\n\n---\n\n')
         const ideaRes = await axios.post(
           `${API_BASE_URL}/v1/ideas`,
-          { workspaceId: Number(workspaceId), content: `[PRD_PIPELINE]\n${body}` },
+          { workspaceId, content: `[PRD_PIPELINE]\n${body}` },
           { headers: { ...headers, 'Content-Type': 'application/json' } }
         )
         const ideaId = ideaRes.data.id
@@ -465,16 +479,54 @@ export default function PRDPage() {
             { headers }
           )
           if (poll.data.status === 'FAILED') throw new Error(poll.data.message || 'PRD 생성 실패')
-          if (['DEPLOYED', 'PRD_GENERATED', 'UI_GENERATED', 'CODE_GENERATED', 'GITHUB_PUSHED'].includes(poll.data.status)) {
+          const isDeployed = poll.data.status === 'DEPLOYED'
+          const fallbackReady =
+            i >= 60 &&
+            ['PRD_GENERATED', 'UI_GENERATED', 'CODE_GENERATED', 'GITHUB_PUSHED'].includes(
+              poll.data.status
+            ) &&
+            Boolean((poll.data.prdMarkdown || '').trim())
+          if (isDeployed || fallbackReady) {
             clearInterval(stepTimer)
             setGenStep(STEPS.length - 1)
+            const p = poll.data as {
+              prdMarkdown?: string
+              prdViewUrl?: string
+              prdViewPath?: string
+              workspaceId?: number
+              ideaId?: number
+              jobId?: number
+              vercelPreviewUrl?: string
+              vercelProductionUrl?: string
+              githubRepoUrl?: string
+            }
+            const ws = p.workspaceId ?? workspaceId
+            const jid = p.jobId ?? jobId
             setResult({
               projectName,
               cards: selected.map(c => c.text),
               generatedAt: new Date().toLocaleDateString('ko-KR'),
-              prdMarkdown: poll.data.prdMarkdown || undefined,
+              prdMarkdown: p.prdMarkdown || undefined,
+              prdViewUrl: p.prdViewUrl || undefined,
+              prdViewPath: p.prdViewPath || undefined,
+              ideaId: p.ideaId ?? ideaId,
+              jobId: jid,
+              workspaceId: ws ?? undefined,
+              vercelPreviewUrl: p.vercelPreviewUrl || undefined,
+              vercelProductionUrl: p.vercelProductionUrl || undefined,
+              githubRepoUrl: p.githubRepoUrl || undefined,
             })
             setGenState('done')
+            const toOpen =
+              (typeof p.prdViewUrl === 'string' && p.prdViewUrl.trim()) ||
+              (p.prdViewPath &&
+                `${window.location.origin}${p.prdViewPath.startsWith('/') ? '' : '/'}${p.prdViewPath}`) ||
+              (ws != null && jid != null
+                ? `${window.location.origin}/prd/workspaces/${ws}/prds/${jid}`
+                : '')
+            if (toOpen) {
+              window.open(toOpen, '_blank', 'noopener,noreferrer')
+            }
             return
           }
         }
@@ -616,6 +668,17 @@ export default function PRDPage() {
             )}
             {genState === 'done' && result && (
               <div className={styles.resultWrap} ref={resultRef}>
+                {((result.workspaceId != null && result.jobId != null) || result.prdViewUrl) && (
+                  <PrdCompletionPanel
+                    info={{
+                      workspaceId: result.workspaceId,
+                      jobId: result.jobId,
+                      ideaId: result.ideaId,
+                      prdViewUrl: result.prdViewUrl,
+                      prdViewPath: result.prdViewPath,
+                    }}
+                  />
+                )}
                 {/* Tab bar */}
                 <div className={styles.tabBar}>
                   {TABS.map(tab => {

--- a/src/pages/PRDResultPage/PRDResultPage.module.css
+++ b/src/pages/PRDResultPage/PRDResultPage.module.css
@@ -7,6 +7,11 @@
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
 }
 
+/* 실 PRD 문서 모드: 조금 더 잡지·문서 느낌 */
+.pageDocument {
+  background: linear-gradient(180deg, #f1f5f9 0%, #f8fafc 32%, #f8fafc 100%);
+}
+
 /* ─── Nav ────────────────────────────────────────────────────────────────── */
 
 .nav {
@@ -332,6 +337,29 @@
   font-size: 0.82rem;
   color: #6b7280;
   font-weight: 500;
+}
+
+.heroDocument {
+  background: linear-gradient(145deg, #ffffff 0%, #f8fafc 48%, #ecfdf5 100%);
+  border: 1px solid #e2e8f0;
+  border-radius: 20px;
+  padding: 36px 40px;
+  margin-bottom: 24px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.06);
+}
+
+.heroBadgeMuted {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 50px;
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: #475569;
+  margin-bottom: 14px;
 }
 
 /* ─── Section ────────────────────────────────────────────────────────────── */
@@ -993,6 +1021,40 @@
   .metricsGrid { grid-template-columns: 1fr 1fr; }
 }
 
+/* PRD 본문 래퍼(마크다운 렌더) */
+.prdMarkdownShell {
+  margin: 0;
+  padding: 8px 28px 32px;
+  background: #fff;
+  border-radius: 0 0 12px 12px;
+}
+
+@media (max-width: 600px) {
+  .prdMarkdownShell {
+    padding: 4px 16px 24px;
+  }
+}
+
+.prdMdMeta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 10px;
+  margin: 0 0 1rem;
+  padding: 0 0 0.75rem;
+  max-width: 48rem;
+  margin-left: auto;
+  margin-right: auto;
+  font-size: 0.8rem;
+  color: #64748b;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.prdMdMeta strong {
+  color: #475569;
+  font-weight: 600;
+}
+
 /* Capstone 파이프라인 PRD 원문 */
 .prototypeHint {
   margin: 0 0 16px;
@@ -1013,6 +1075,62 @@
   white-space: pre-wrap;
   word-break: break-word;
   border: 1px solid #1e293b;
+}
+
+/* 공개용 PRD 본문: 카드(헤더 + 마크다운 렌더) */
+.prdDocumentSection {
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 4px 24px rgba(15, 23, 42, 0.06);
+  border-radius: 12px;
+  background: #fff;
+  overflow: hidden;
+}
+
+/* 레거시: 원문 <pre> 폴백에만 사용 */
+.markdownProse {
+  margin: 0;
+  padding: 28px 32px;
+  background: #ffffff;
+  color: #1e293b;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  line-height: 1.75;
+  font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Apple SD Gothic Neo', sans-serif;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  border: 1px solid #e2e8f0;
+  max-height: none;
+}
+
+.previewFrameSection {
+  overflow: hidden;
+}
+
+.previewFrame {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #f8fafc;
+  margin-top: 4px;
+}
+
+.previewIframe {
+  width: 100%;
+  min-height: 480px;
+  border: none;
+  display: block;
+  background: #fff;
+}
+
+.previewErrorBox {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #fffbeb;
+  padding: 20px 24px;
+  color: #92400e;
+  font-size: 0.9rem;
+  line-height: 1.5;
 }
 
 .prototypeLinks {

--- a/src/pages/PRDResultPage/PRDResultPage.tsx
+++ b/src/pages/PRDResultPage/PRDResultPage.tsx
@@ -1,13 +1,16 @@
 import { useState, useEffect, useRef } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useSearchParams } from 'react-router-dom'
+import axios from 'axios'
+import { API_BASE_URL } from '../../config/api'
 import {
   Sparkles, ExternalLink, Copy, Check, Menu, X,
-  FileText, Target, Lightbulb, Users, Code2, Calendar,
+  FileText, Target, Users, Code2, Calendar,
   TrendingUp, AlertTriangle, BookOpen, ChevronRight,
   Clock, Zap, Shield, Globe, ArrowUpRight, Download,
   CheckCircle2, Circle, Hash
 } from 'lucide-react'
 import styles from './PRDResultPage.module.css'
+import { PrdMarkdownBody } from '../../components/prd/PrdMarkdownBody'
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -20,13 +23,80 @@ interface PRDData {
   timeline: string
   template: 'minimal' | 'standard' | 'detailed'
   generatedAt?: string
-  /** Capstone 프로토타입 파이프라인에서 받은 마크다운 PRD */
+  /** API에서 받은 PRD 본문(마크다운) */
   prdMarkdown?: string
   vercelPreviewUrl?: string
   vercelProductionUrl?: string
   githubRepoUrl?: string
   prototypeMessage?: string
   simulated?: boolean
+  sourceFiles?: { path: string; content: string }[]
+}
+
+type DebugAuthInfo = {
+  userId?: number
+  userEmail?: string
+  userName?: string
+  workspaceIds?: number[]
+  targetWorkspaceId?: number
+  targetPrdId?: number
+  tokenExists: boolean
+  lastErrorStatus?: number
+  lastErrorMessage?: string
+}
+
+function isLocalDevBrowser() {
+  if (typeof window === 'undefined') return false
+  const h = window.location.hostname
+  return h === 'localhost' || h === '127.0.0.1'
+}
+
+async function tryDevBootstrapLogin(): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/v1/auth/dev/bootstrap`, {
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+    })
+    if (!res.ok) return false
+    const data = await res.json()
+    if (data?.accessToken) {
+      localStorage.setItem('accessToken', data.accessToken)
+      if (data?.refreshToken) {
+        localStorage.setItem('refreshToken', data.refreshToken)
+      }
+      return true
+    }
+  } catch {
+    // noop
+  }
+  return false
+}
+
+function isVercelRelatedUrl(url: string | undefined): boolean {
+  if (!url) return false
+  const u = url.toLowerCase()
+  return u.includes('vercel') || u.includes('vercel.app') || u.includes('now.sh')
+}
+
+function markdownPlainExcerpt(md: string, maxLen: number): string {
+  const stripped = md
+    .replace(/^#+\s+.*/gm, '')
+    .replace(/[*_`#[\]]/g, '')
+    .replace(/\n+/g, ' ')
+    .trim()
+  if (stripped.length <= maxLen) return stripped
+  return `${stripped.slice(0, maxLen).trim()}…`
+}
+
+/** PRD 본문 대략 읽기 시간(한·영 혼합, 약 800자/분) */
+function estimateReadingMinutes(md: string): number {
+  const t = md.replace(/\s+/g, ' ').trim()
+  if (t.length === 0) return 1
+  return Math.max(1, Math.ceil(t.length / 800))
+}
+
+function countMarkdownH2Sections(md: string): number {
+  return (md.match(/^##\s+[^\n#]+/gm) || []).length
 }
 
 // ─── Mock PRD content generator ────────────────────────────────────────────
@@ -74,7 +144,7 @@ function generatePRD(data: PRDData) {
       frontend: techList.slice(0, 2).length > 0 ? techList.slice(0, 2) : ['React', 'TypeScript'],
       backend: techList.slice(2, 4).length > 0 ? techList.slice(2, 4) : ['Node.js', 'Express'],
       database: techList.slice(4, 5).length > 0 ? techList.slice(4, 5) : ['PostgreSQL'],
-      infra: ['Vercel', 'AWS S3', 'GitHub Actions'],
+      infra: ['클라우드', 'CI/CD', '모니터링'],
     },
     timeline: {
       duration: data.timeline || '3개월',
@@ -126,7 +196,7 @@ const RISK_STYLE: Record<string, string> = {
 
 // ─── TOC ──────────────────────────────────────────────────────────────────
 
-const TOC_ITEMS = [
+const DEFAULT_TOC_ITEMS = [
   { id: 'overview', label: '개요', icon: FileText },
   { id: 'problem', label: '문제 정의', icon: AlertTriangle },
   { id: 'goals', label: '목표', icon: Target },
@@ -140,11 +210,22 @@ const TOC_ITEMS = [
 // ─── Main ─────────────────────────────────────────────────────────────────
 
 export default function PRDResultPage() {
-  const { id } = useParams<{ id: string }>()
+  const { id, workspaceId: wsPath, prdId: prdPath } = useParams<{
+    id?: string
+    workspaceId?: string
+    prdId?: string
+  }>()
+  const [searchParams] = useSearchParams()
+  const jobIdParam = searchParams.get('jobId')
   const [data, setData] = useState<PRDData | null>(null)
   const [activeSection, setActiveSection] = useState('overview')
   const [tocOpen, setTocOpen] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [selectedSourcePath, setSelectedSourcePath] = useState<string | null>(null)
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [debugAuth, setDebugAuth] = useState<DebugAuthInfo | null>(null)
   const contentRef = useRef<HTMLDivElement>(null)
 
   // PRD 결과 페이지에서 스크롤 활성화
@@ -178,11 +259,227 @@ export default function PRDResultPage() {
   }, [])
 
   useEffect(() => {
-    // 실제 구현: API로 PRD 데이터 fetch
-    // const res = await axios.get(`${API_BASE_URL}/v1/prd/${id}`)
-    // setData(res.data)
+    const load = async () => {
+      setLoadError(null)
+      setDebugAuth(null)
+      // 워크스페이스 공유 URL: /prd/workspaces/:workspaceId/prds/:prdId
+      if (wsPath && prdPath) {
+        let token = localStorage.getItem('accessToken')
+        const ws = parseInt(wsPath, 10)
+        const prd = parseInt(prdPath, 10)
+        if (!token && isLocalDevBrowser()) {
+          const ok = await tryDevBootstrapLogin()
+          if (ok) token = localStorage.getItem('accessToken')
+        }
+        if (token && !Number.isNaN(ws) && !Number.isNaN(prd)) {
+          try {
+            const headers = { Authorization: `Bearer ${token}` }
+            try {
+              const [meRes, wsRes] = await Promise.all([
+                axios.get(`${API_BASE_URL}/v1/users/me`, { headers }),
+                axios.get(`${API_BASE_URL}/v1/workspaces`, { headers }),
+              ])
+              const wsData = Array.isArray(wsRes.data) ? wsRes.data : []
+              const wsIds = wsData
+                .map((w: any) => Number(w?.workspaceId ?? w?.id))
+                .filter((id: number) => Number.isFinite(id))
+              setDebugAuth({
+                tokenExists: true,
+                userId: Number(meRes.data?.id),
+                userEmail: meRes.data?.email,
+                userName: meRes.data?.name,
+                workspaceIds: wsIds,
+                targetWorkspaceId: ws,
+                targetPrdId: prd,
+              })
+            } catch {
+              setDebugAuth({
+                tokenExists: true,
+                targetWorkspaceId: ws,
+                targetPrdId: prd,
+              })
+            }
+            setPreviewError(null)
+            const [jobRes, filesRes] = await Promise.all([
+              axios.get(`${API_BASE_URL}/v1/workspaces/${ws}/prds/${prd}`, { headers }),
+              axios
+                .get(`${API_BASE_URL}/v1/workspaces/${ws}/prds/${prd}/source-files`, { headers })
+                .catch(() => ({ data: [] as { path: string; content: string }[] })),
+            ])
+            try {
+              const previewRes = await axios.get(
+                `${API_BASE_URL}/v1/workspaces/${ws}/prds/${prd}/preview`,
+                { headers, responseType: 'text' }
+              )
+              setPreviewHtml(typeof previewRes.data === 'string' ? previewRes.data : null)
+            } catch {
+              setPreviewHtml(null)
+              setPreviewError('미리보기를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.')
+            }
+            const j = jobRes.data as {
+              prdMarkdown?: string
+              vercelPreviewUrl?: string
+              vercelProductionUrl?: string
+              githubRepoUrl?: string
+              message?: string
+              simulated?: boolean
+            }
+            const fileList = Array.isArray(filesRes.data) ? filesRes.data : []
+            const sourceFiles = fileList.map(
+              (f: { path: string; content: string }) => ({ path: f.path, content: f.content })
+            )
+            if (sourceFiles.length > 0) setSelectedSourcePath(sourceFiles[0].path)
+            const firstLine = (j.prdMarkdown || '').split('\n').find((l) => l.trim().length > 0) || 'PRD'
+            const projectName = firstLine.replace(/^#+\s*/, '').slice(0, 80) || `Workspace ${ws} PRD`
+            setData({
+              projectName,
+              idea: (j.prdMarkdown || '').slice(0, 500) || '팀 PRD',
+              targetUsers: '서비스 사용자',
+              features: ['AI 생성 PRD', '팀 협업', '서버 배포 URL'],
+              techStack: 'React, Spring Boot (Capstone API)',
+              timeline: '—',
+              template: 'standard',
+              generatedAt: new Date().toLocaleDateString('ko-KR'),
+              prdMarkdown: j.prdMarkdown,
+              vercelPreviewUrl: j.vercelPreviewUrl,
+              vercelProductionUrl: j.vercelProductionUrl,
+              githubRepoUrl: j.githubRepoUrl,
+              prototypeMessage: j.message,
+              simulated: j.simulated,
+              sourceFiles,
+            })
+            return
+          } catch (e: any) {
+            console.error('[PRDResultPage] workspace PRD API 로드 실패', e)
+            setPreviewHtml(null)
+            const status = e?.response?.status
+            if (status === 401 || status === 403) {
+              setPreviewError('권한이 없어 PRD를 불러오지 못했습니다. 해당 워크스페이스 멤버 계정으로 다시 로그인해 주세요.')
+              setLoadError('접근 권한이 없습니다 (401/403). 워크스페이스 멤버 권한을 확인해 주세요.')
+              setDebugAuth(prev => ({
+                tokenExists: Boolean(token),
+                targetWorkspaceId: ws,
+                targetPrdId: prd,
+                ...(prev || {}),
+                lastErrorStatus: status,
+                lastErrorMessage: e?.response?.data?.message || e?.message,
+              }))
+            } else {
+              setPreviewError('문서를 불러오는 중 문제가 있어 미리보기를 표시하지 못했습니다.')
+              setLoadError('문서를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.')
+              setDebugAuth(prev => ({
+                tokenExists: Boolean(token),
+                targetWorkspaceId: ws,
+                targetPrdId: prd,
+                ...(prev || {}),
+                lastErrorStatus: status,
+                lastErrorMessage: e?.response?.data?.message || e?.message,
+              }))
+            }
+            return
+          }
+        }
+        setLoadError('로그인이 필요합니다. 로그인 후 PRD URL을 다시 열어주세요.')
+        setPreviewError('로그인 후에만 미리보기를 볼 수 있습니다.')
+        return
+      }
 
-    // Mock: sessionStorage에서 로드 (일반 id 또는 ws_{workspaceId} 형식 모두 지원)
+      // 기존 URL: /prd/result/:ideaId?jobId=...
+      if (id && jobIdParam) {
+        let token = localStorage.getItem('accessToken')
+        const ideaId = parseInt(id, 10)
+        const jId = parseInt(jobIdParam, 10)
+        if (!token && isLocalDevBrowser()) {
+          const ok = await tryDevBootstrapLogin()
+          if (ok) token = localStorage.getItem('accessToken')
+        }
+        if (token && !Number.isNaN(ideaId) && !Number.isNaN(jId)) {
+          try {
+            const headers = { Authorization: `Bearer ${token}` }
+            setPreviewError(null)
+            const [jobRes, filesRes] = await Promise.all([
+              axios.get(`${API_BASE_URL}/v1/ideas/${ideaId}/prototype/jobs/${jId}`, { headers }),
+              axios
+                .get(
+                  `${API_BASE_URL}/v1/ideas/${ideaId}/prototype/jobs/${jId}/source-files`,
+                  { headers }
+                )
+                .catch(() => ({ data: [] as { path: string; content: string }[] })),
+            ])
+            const jMeta = jobRes.data as { workspaceId?: number }
+            const wsFromQuery = parseInt(searchParams.get('workspaceId') || '', 10)
+            const wsIdForPreview =
+              !Number.isNaN(wsFromQuery)
+                ? wsFromQuery
+                : (typeof jMeta.workspaceId === 'number' ? jMeta.workspaceId : NaN)
+            if (!Number.isNaN(wsIdForPreview)) {
+              try {
+                const previewRes = await axios.get(
+                  `${API_BASE_URL}/v1/workspaces/${wsIdForPreview}/prds/${jId}/preview`,
+                  { headers, responseType: 'text' }
+                )
+                setPreviewHtml(typeof previewRes.data === 'string' ? previewRes.data : null)
+              } catch {
+                setPreviewHtml(null)
+                setPreviewError('미리보기를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.')
+              }
+            } else {
+              setPreviewHtml(null)
+              setPreviewError('이 주소만으로는 미리보기를 열 수 없습니다. 팀이 공유한 PRD 링크로 다시 열어 주세요.')
+            }
+            const j = jobRes.data as {
+              prdMarkdown?: string
+              vercelPreviewUrl?: string
+              vercelProductionUrl?: string
+              githubRepoUrl?: string
+              message?: string
+              simulated?: boolean
+            }
+            const fileList = Array.isArray(filesRes.data) ? filesRes.data : []
+            const sourceFiles = fileList.map(
+              (f: { path: string; content: string }) => ({
+                path: f.path,
+                content: f.content,
+              })
+            )
+            if (sourceFiles.length > 0) {
+              setSelectedSourcePath(sourceFiles[0].path)
+            }
+            const firstLine = (j.prdMarkdown || '').split('\n').find((l) => l.trim().length > 0) || 'PRD'
+            const projectName = firstLine.replace(/^#+\s*/, '').slice(0, 80) || '프로젝트 PRD'
+            setData({
+              projectName,
+              idea: (j.prdMarkdown || '').slice(0, 500) || '팀 PRD',
+              targetUsers: '서비스 사용자',
+              features: ['AI 생성 PRD', '팀 협업', 'API 연동'],
+              techStack: 'React, Spring Boot (Capstone API)',
+              timeline: '—',
+              template: 'standard',
+              generatedAt: new Date().toLocaleDateString('ko-KR'),
+              prdMarkdown: j.prdMarkdown,
+              vercelPreviewUrl: j.vercelPreviewUrl,
+              vercelProductionUrl: j.vercelProductionUrl,
+              githubRepoUrl: j.githubRepoUrl,
+              prototypeMessage: j.message,
+              simulated: j.simulated,
+              sourceFiles,
+            })
+            return
+          } catch (e: any) {
+            console.error('[PRDResultPage] API 로드 실패, sessionStorage로 대체', e)
+            setPreviewHtml(null)
+            const status = e?.response?.status
+            if (status === 401 || status === 403) {
+              setPreviewError('권한이 없어 PRD를 불러오지 못했습니다. 다시 로그인하거나 워크스페이스 권한을 확인해 주세요.')
+              setLoadError('접근 권한이 없습니다 (401/403).')
+            } else {
+              setPreviewError('문서를 불러오는 중 문제가 있어 미리보기를 표시하지 못했습니다.')
+            }
+          }
+        }
+      }
+
+      // sessionStorage (일반 id 또는 ws_{workspaceId} 형식 모두 지원)
     const key1 = id ? `prd_${id}` : null
     const key2 = id ? `prd_ws_${id?.replace('ws_', '')}` : null
     const stored = (key1 && sessionStorage.getItem(key1))
@@ -231,26 +528,50 @@ export default function PRDResultPage() {
         template: 'detailed',
         generatedAt: new Date().toLocaleDateString('ko-KR'),
       })
+      setPreviewHtml(null)
+      setPreviewError('이 페이지만으로는 미리보기를 준비할 수 없습니다. PRD를 다시 연 뒤 시도해 주세요.')
     }
-  }, [id])
+    }
+    void load()
+  }, [id, jobIdParam, wsPath, prdPath])
 
   // Scroll-based active section
+  const hasRealPrd = Boolean(data?.prdMarkdown && data.prdMarkdown.trim().length > 0)
+  const showDevExtras = isLocalDevBrowser()
+  const tocItems = hasRealPrd
+    ? [
+        { id: 'ai-prd-md', label: '문서', icon: FileText },
+        ...(showDevExtras && data?.sourceFiles && data.sourceFiles.length > 0
+          ? [{ id: 'ai-source', label: '소스 (개발)', icon: Code2 }]
+          : []),
+        ...(previewHtml || previewError
+          ? [{ id: 'ai-preview', label: '미리보기', icon: Globe }]
+          : []),
+      ]
+    : DEFAULT_TOC_ITEMS
+
+  useEffect(() => {
+    if (hasRealPrd) {
+      setActiveSection('ai-prd-md')
+    }
+  }, [hasRealPrd])
+
   useEffect(() => {
     const handleScroll = () => {
-      const sections = TOC_ITEMS.map(item => document.getElementById(item.id))
+      const sections = tocItems.map(item => document.getElementById(item.id))
       const scrollY = window.scrollY + 120
 
       for (let i = sections.length - 1; i >= 0; i--) {
         const el = sections[i]
         if (el && el.offsetTop <= scrollY) {
-          setActiveSection(TOC_ITEMS[i].id)
+          setActiveSection(tocItems[i].id)
           break
         }
       }
     }
     window.addEventListener('scroll', handleScroll, { passive: true })
     return () => window.removeEventListener('scroll', handleScroll)
-  }, [])
+  }, [tocItems])
 
   function scrollTo(id: string) {
     const el = document.getElementById(id)
@@ -285,15 +606,31 @@ export default function PRDResultPage() {
     return (
       <div className={styles.loadingPage}>
         <div className={styles.loadingSpinner} />
-        <p>PRD 문서를 불러오는 중...</p>
+        <p>{loadError || 'PRD 문서를 불러오는 중...'}</p>
+        {isLocalDevBrowser() && debugAuth && (
+          <div style={{ marginTop: 14, maxWidth: 760, textAlign: 'left', background: '#fff', border: '1px solid #e2e8f0', borderRadius: 10, padding: 12 }}>
+            <div style={{ fontWeight: 700, marginBottom: 6 }}>권한 디버그 정보</div>
+            <div style={{ fontSize: 13, color: '#334155', lineHeight: 1.7 }}>
+              <div>tokenExists: {String(debugAuth.tokenExists)}</div>
+              <div>user: {debugAuth.userName || '-'} ({debugAuth.userEmail || '-'}) / id={String(debugAuth.userId ?? '-')}</div>
+              <div>target: workspace={String(debugAuth.targetWorkspaceId ?? '-')}, prd={String(debugAuth.targetPrdId ?? '-')}</div>
+              <div>myWorkspaces: {(debugAuth.workspaceIds || []).join(', ') || '-'}</div>
+              <div>lastError: {String(debugAuth.lastErrorStatus ?? '-')} / {debugAuth.lastErrorMessage || '-'}</div>
+            </div>
+          </div>
+        )}
       </div>
     )
   }
 
   const prd = generatePRD(data)
+  const prdH2SectionCount =
+    data.prdMarkdown && data.prdMarkdown.trim().length > 0
+      ? countMarkdownH2Sections(data.prdMarkdown)
+      : 0
 
   return (
-    <div className={styles.page}>
+    <div className={`${styles.page} ${hasRealPrd ? styles.pageDocument : ''}`}>
       {/* ── Top Nav ── */}
       <header className={styles.nav}>
         <div className={styles.navLeft}>
@@ -302,14 +639,16 @@ export default function PRDResultPage() {
           </div>
           <div className={styles.navMeta}>
             <span className={styles.navTitle}>{data.projectName}</span>
-            <span className={styles.navBadge}>PRD v{prd.overview.version}</span>
+            <span className={styles.navBadge}>
+              {hasRealPrd ? 'PRD' : `v${prd.overview.version}`}
+            </span>
           </div>
         </div>
 
         <div className={styles.navRight}>
           <span className={styles.navDate}>
             <Clock size={13} />
-            {prd.overview.createdAt}
+            {data.generatedAt || prd.overview.createdAt}
           </span>
           <button className={styles.navBtn} onClick={copyUrl}>
             {copied ? <Check size={15} /> : <Copy size={15} />}
@@ -334,7 +673,7 @@ export default function PRDResultPage() {
           <div className={styles.tocInner}>
             <div className={styles.tocHeader}>목차</div>
             <nav>
-              {TOC_ITEMS.map(item => {
+              {tocItems.map(item => {
                 const Icon = item.icon
                 const active = activeSection === item.id
                 return (
@@ -353,7 +692,7 @@ export default function PRDResultPage() {
 
             <div className={styles.tocFooter}>
               <div className={styles.tocStatusDot} />
-              <span>{prd.overview.status}</span>
+              <span>{hasRealPrd ? '팀 공유 문서' : prd.overview.status}</span>
             </div>
           </div>
         </aside>
@@ -362,30 +701,38 @@ export default function PRDResultPage() {
         <main className={styles.content} ref={contentRef}>
 
           {/* Hero */}
-          <div className={styles.hero}>
-            <div className={styles.heroBadge}>
+          <div className={hasRealPrd ? styles.heroDocument : styles.hero}>
+            <div className={hasRealPrd ? styles.heroBadgeMuted : styles.heroBadge}>
               <Sparkles size={13} />
-              AI Generated PRD
+              {hasRealPrd ? '제품 요구사항' : 'AI Generated PRD'}
             </div>
             <h1 className={styles.heroTitle}>{data.projectName}</h1>
-            <p className={styles.heroSubtitle}>{prd.overview.description.slice(0, 120)}...</p>
+            <p className={styles.heroSubtitle}>
+              {hasRealPrd && data.prdMarkdown
+                ? markdownPlainExcerpt(data.prdMarkdown, 200)
+                : `${prd.overview.description.slice(0, 120)}...`}
+            </p>
             <div className={styles.heroMeta}>
               <span className={styles.heroMetaItem}>
-                <Users size={14} />
-                {data.targetUsers}
-              </span>
-              <span className={styles.heroMetaItem}>
                 <Calendar size={14} />
-                {prd.timeline.duration}
+                {data.generatedAt || prd.overview.createdAt}
               </span>
-              <span className={styles.heroMetaItem}>
-                <Globe size={14} />
-                배포 완료
-              </span>
+              {!hasRealPrd && (
+                <>
+                  <span className={styles.heroMetaItem}>
+                    <Users size={14} />
+                    {data.targetUsers}
+                  </span>
+                  <span className={styles.heroMetaItem}>
+                    <Clock size={14} />
+                    {prd.timeline.duration}
+                  </span>
+                </>
+              )}
             </div>
           </div>
 
-          {/* ── Overview ── */}
+          {!hasRealPrd && (
           <section className={styles.section} id="overview">
             <SectionHeader icon={FileText} title="개요" id="overview-h" />
             <div className={styles.overviewGrid}>
@@ -410,37 +757,116 @@ export default function PRDResultPage() {
               </div>
             </div>
           </section>
+          )}
 
           {data.prdMarkdown && data.prdMarkdown.trim().length > 0 && (
-            <section className={styles.section} id="ai-prd-md">
-              <SectionHeader icon={BookOpen} title="백엔드 생성 PRD (원문)" id="ai-prd-md-h" />
-              {data.prototypeMessage && (
-                <p className={styles.prototypeHint}>{data.prototypeMessage}</p>
-              )}
-              <pre className={styles.markdownSource}>{data.prdMarkdown}</pre>
-              <div className={styles.prototypeLinks}>
-                {data.vercelPreviewUrl && (
-                  <a className={styles.prototypeLink} href={data.vercelPreviewUrl} target="_blank" rel="noreferrer">
-                    <ExternalLink size={14} />
-                    Vercel 프리뷰
-                  </a>
-                )}
-                {data.vercelProductionUrl && (
-                  <a className={styles.prototypeLink} href={data.vercelProductionUrl} target="_blank" rel="noreferrer">
-                    <ExternalLink size={14} />
-                    프로덕션
-                  </a>
-                )}
-                {data.githubRepoUrl && (
-                  <a className={styles.prototypeLink} href={data.githubRepoUrl} target="_blank" rel="noreferrer">
-                    <ExternalLink size={14} />
-                    GitHub 저장소
-                  </a>
-                )}
+            <section className={`${styles.section} ${hasRealPrd ? styles.prdDocumentSection : ''}`} id="ai-prd-md">
+              <SectionHeader icon={BookOpen} title="PRD" id="ai-prd-md-h" />
+              <div className={styles.prdMarkdownShell}>
+                <div className={styles.prdMdMeta} aria-label="문서 정보">
+                  <span>
+                    본문 <strong>{data.prdMarkdown.length.toLocaleString('ko-KR')}</strong>자
+                  </span>
+                  <span aria-hidden>·</span>
+                  <span>
+                    읽는 시간 약 <strong>{estimateReadingMinutes(data.prdMarkdown)}</strong>분
+                  </span>
+                  {prdH2SectionCount > 0 && (
+                    <>
+                      <span aria-hidden>·</span>
+                      <span>
+                        <strong>{prdH2SectionCount}</strong>개 섹션(##)
+                      </span>
+                    </>
+                  )}
+                </div>
+                <PrdMarkdownBody markdown={data.prdMarkdown} />
               </div>
+              {(
+                (data.vercelPreviewUrl && !isVercelRelatedUrl(data.vercelPreviewUrl)) ||
+                (data.vercelProductionUrl && !isVercelRelatedUrl(data.vercelProductionUrl)) ||
+                (showDevExtras && data.githubRepoUrl)
+              ) && (
+                <div className={styles.prototypeLinks}>
+                  {data.vercelPreviewUrl && !isVercelRelatedUrl(data.vercelPreviewUrl) && (
+                    <a className={styles.prototypeLink} href={data.vercelPreviewUrl} target="_blank" rel="noreferrer">
+                      <ExternalLink size={14} />
+                      외부 미리보기
+                    </a>
+                  )}
+                  {data.vercelProductionUrl && !isVercelRelatedUrl(data.vercelProductionUrl) && (
+                    <a className={styles.prototypeLink} href={data.vercelProductionUrl} target="_blank" rel="noreferrer">
+                      <ExternalLink size={14} />
+                      서비스 열기
+                    </a>
+                  )}
+                  {showDevExtras && data.githubRepoUrl && (
+                    <a className={styles.prototypeLink} href={data.githubRepoUrl} target="_blank" rel="noreferrer">
+                      <ExternalLink size={14} />
+                      GitHub
+                    </a>
+                  )}
+                </div>
+              )}
             </section>
           )}
 
+          {showDevExtras && data.sourceFiles && data.sourceFiles.length > 0 && (
+            <section className={styles.section} id="ai-source">
+              <SectionHeader icon={Code2} title="생성된 코드 (개발용)" id="ai-source-h" />
+              <p className={styles.prototypeHint} style={{ marginBottom: 12 }}>
+                로컬에서만 표시됩니다. 실제 팀·고객 공유 화면에는 포함되지 않습니다.
+              </p>
+              <div style={{ marginBottom: 10, display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
+                <span style={{ fontSize: 13, color: '#64748b' }}>파일:</span>
+                {data.sourceFiles.map((f) => (
+                  <button
+                    key={f.path}
+                    type="button"
+                    onClick={() => setSelectedSourcePath(f.path)}
+                    style={{
+                      fontSize: 12,
+                      padding: '4px 10px',
+                      borderRadius: 6,
+                      border: '1px solid #e2e8f0',
+                      background: selectedSourcePath === f.path ? '#eef2ff' : '#fff',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {f.path}
+                  </button>
+                ))}
+              </div>
+              <pre className={styles.markdownSource} style={{ maxHeight: 480, overflow: 'auto' }}>
+                {(
+                  data.sourceFiles.find((f) => f.path === selectedSourcePath) || data.sourceFiles[0]
+                )?.content ?? ''}
+              </pre>
+            </section>
+          )}
+
+          {(previewHtml || previewError) && (
+            <section className={`${styles.section} ${hasRealPrd ? styles.previewFrameSection : ''}`} id="ai-preview">
+              <SectionHeader icon={Globe} title="화면 미리보기" id="ai-preview-h" />
+              {previewHtml ? (
+                <div className={styles.previewFrame}>
+                  <iframe
+                    title="prototype-preview"
+                    srcDoc={previewHtml}
+                    sandbox="allow-scripts allow-same-origin"
+                    className={styles.previewIframe}
+                  />
+                </div>
+              ) : (
+                <div className={styles.previewErrorBox}>
+                  {previewError || '미리보기를 불러오지 못했습니다.'}
+                </div>
+              )}
+            </section>
+          )}
+
+          {!hasRealPrd && (
+            <>
           {/* ── Problem ── */}
           <section className={styles.section} id="problem">
             <SectionHeader icon={AlertTriangle} title="문제 정의" id="problem-h" />
@@ -598,15 +1024,19 @@ export default function PRDResultPage() {
               ))}
             </div>
           </section>
+            </>
+          )}
 
           {/* Footer */}
           <footer className={styles.docFooter}>
             <div className={styles.docFooterLogo}>
               <Sparkles size={16} />
-              AI PRD Generator
+              {hasRealPrd ? '팀 PRD' : 'AI PRD Generator'}
             </div>
             <p className={styles.docFooterText}>
-              이 문서는 AI에 의해 자동 생성되었습니다. 실제 개발 전 팀 리뷰를 권장합니다.
+              {hasRealPrd
+                ? '팀·이해관계자 검토를 위해 공유될 수 있는 요약 문서입니다. 실행 환경에 따라 미리보기는 달라질 수 있습니다.'
+                : '이 문서는 AI에 의해 자동 생성되었습니다. 실제 개발 전 팀 리뷰를 권장합니다.'}
             </p>
           </footer>
         </main>

--- a/src/pages/infinite-canvas/InfiniteCanvasPage.jsx
+++ b/src/pages/infinite-canvas/InfiniteCanvasPage.jsx
@@ -1076,6 +1076,28 @@ const InfiniteCanvasPage = () => {
       } catch (error) {
         console.error('아이디어 업데이트 처리 오류:', error);
       }
+    },
+    onPrototypeReady: (payload) => {
+      const p = payload || {};
+      const fromApi = typeof p.prdViewUrl === 'string' && p.prdViewUrl.trim() ? p.prdViewUrl.trim() : '';
+      const rel =
+        p.prdViewPath ||
+        (p.ideaId != null && p.jobId != null
+          ? `/prd/workspaces/${p.workspaceId ?? workspaceId}/prds/${p.jobId}`
+          : null);
+      if (!fromApi && !rel) return;
+      const url = fromApi
+        || (rel.startsWith('http') ? rel : `${window.location.origin}${rel.startsWith('/') ? '' : '/'}${rel}`);
+      setToast({
+        message: 'PRD·프로토타입이 준비되었습니다. 새 탭에서 열었습니다.',
+        type: 'success',
+        isVisible: true
+      });
+      try {
+        window.open(url, '_blank', 'noopener,noreferrer');
+      } catch (e) {
+        console.warn('PRD 뷰어 새 탭 열기 실패', e);
+      }
     }
   });
 

--- a/src/pages/infinite-canvas/hooks/useCanvasWebSocket.js
+++ b/src/pages/infinite-canvas/hooks/useCanvasWebSocket.js
@@ -89,6 +89,20 @@ export const useCanvasWebSocket = (workspaceId, currentUserId, callbacks = {}) =
           }
         });
 
+        // PRD/프로토타입 파이프라인 완료 (같은 워크스페이스 팀 전원)
+        const prototypePath = `/topic/workspace/${workspaceId}/prototype`;
+        console.log('[캔버스 웹소켓] 프로토타입 구독:', prototypePath);
+        stompClient.subscribe(prototypePath, (message) => {
+          try {
+            const payload = JSON.parse(message.body);
+            if (callbacksRef.current.onPrototypeReady) {
+              callbacksRef.current.onPrototypeReady(payload);
+            }
+          } catch (e) {
+            console.error('[캔버스 웹소켓] prototype 메시지 파싱 오류:', e, message.body);
+          }
+        });
+
         // 캔버스 변경 구독 (백엔드: /topic/workspace/{workspaceId}/canvas)
         // 백엔드 형식: {"action": "created|updated|deleted", "data": {...}}
         const canvasSubscriptionPath = `/topic/workspace/${workspaceId}/canvas`;

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,11 +12,11 @@ export default defineConfig({
     proxy: {
       // 로컬 Spring Boot (Capstone) — VITE_API_BASE_URL=/api 일 때 CORS 없이 사용
       '/api': {
-        target: 'http://localhost:8080',
+        target: 'http://51.20.106.74:8080',
         changeOrigin: true,
       },
       '/ws': {
-        target: 'http://localhost:8080',
+        target: 'http://51.20.106.74:8080',
         ws: true, // WebSocket 업그레이드 지원
         changeOrigin: true,
         secure: false,

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,11 +12,11 @@ export default defineConfig({
     proxy: {
       // 로컬 Spring Boot (Capstone) — VITE_API_BASE_URL=/api 일 때 CORS 없이 사용
       '/api': {
-        target: 'http://51.20.106.74:8080',
+        target: 'http://localhost:8080',
         changeOrigin: true,
       },
       '/ws': {
-        target: 'http://51.20.106.74:8080',
+        target: 'http://localhost:8080',
         ws: true, // WebSocket 업그레이드 지원
         changeOrigin: true,
         secure: false,


### PR DESCRIPTION
## 변경사항

* **PRD 마크다운 렌더링 도입**
  * `react-markdown`, `remark-gfm`, `rehype-sanitize` 패키지를 활용한 안전한 마크다운 렌더링 적용
  * 문서 읽기에 최적화된 스타일과 타이포그래피를 갖춘 `PrdMarkdownBody` 컴포넌트 추가
  * PRD 텍스트 출력부를 모두 마크다운 뷰어로 교체 (PRDModal, PRDPage 등)

* **생성 완료 패널 (`PrdCompletionPanel`) 추가**
  * 작업 완료 시 결과 링크(내부 뷰어, Vercel 등)를 보여주고 복사할 수 있는 UI 추가
  * 결과 패널 내에서 Iframe을 통한 화면 미리보기(Preview) 기능 제공

* **생성 파이프라인 Fallback 및 자동화 UX 개선**
  * 긴 생성 시간으로 인한 무한 로딩 방지 (60회 이상 폴링 시 마크다운이 준비되었다면 우선 완료 처리)
  * 작업 완료 시 PRD 뷰어 페이지를 **새 탭으로 자동 실행**하도록 편의성 개선

* **무한 캔버스 웹소켓 연동 (`InfiniteCanvasPage`)**
  * 백엔드 프로토타입 파이프라인 상태 구독 추가 (`/topic/workspace/{workspaceId}/prototype`)
  * 백그라운드에서 작업 완료 시 Toast 알림 제공 및 결과 탭 자동 오픈

* **기타 작업 및 설정**
  * 워크스페이스 기반 PRD 상세 조회를 위한 신규 라우트 추가 (`/prd/workspaces/:workspaceId/prds/:prdId`)